### PR TITLE
test: validate_milestone rejects after end_timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,21 @@ git remote add origin <your-disciplr-contracts-repo-url>
 git push -u origin main
 ```
 
-Replace `<your-disciplr-contracts-repo-url>` with your actual repository URL.
+## Security and Testing
+
+### Security Notes
+
+- **Timestamp Validation**: Milestone validation is strictly prohibited once the ledger timestamp reaches or exceeds `end_timestamp`. This prevents "late" validations and ensures the time-lock is honored.
+- **Authentication**: `validate_milestone` requires authorization from the verifier (if specified) or the creator. This ensures only authorized parties can progress the vault state.
+- **State Integrity**: Operations like `validate_milestone`, `release_funds`, and `cancel_vault` check the current `status` (must be `Active`) to prevent double-spending or invalid state transitions.
+
+### Test Coverage
+
+The project includes unit tests for core logic, specifically:
+- Verification of milestone rejection after `end_timestamp`.
+- Verification of successful milestone validation before `end_timestamp`.
+
+To run tests:
+```bash
+cargo test
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,19 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, Address, BytesN, Env, Symbol,
+    contract, contracterror, contractimpl, contracttype, Address, BytesN, Env, Symbol,
 };
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    VaultNotFound = 1,
+    NotAuthorized = 2,
+    VaultNotActive = 3,
+    InvalidTimestamp = 4,
+    MilestoneExpired = 5,
+}
 
 #[contracttype]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -26,6 +37,13 @@ pub struct ProductivityVault {
     pub status: VaultStatus,
 }
 
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Vault(u32),
+    VaultCount,
+}
+
 #[contract]
 pub struct DisciplrVault;
 
@@ -44,10 +62,18 @@ impl DisciplrVault {
         failure_destination: Address,
     ) -> u32 {
         creator.require_auth();
-        // TODO: pull USDC from creator to this contract
-        // For now, just store vault metadata (storage key pattern would be used in full impl)
+
+        if end_timestamp <= start_timestamp {
+            panic!("end_timestamp must be greater than start_timestamp");
+        }
+
+        let mut vault_count: u32 = env.storage().instance().get(&DataKey::VaultCount).unwrap_or(0);
+        let vault_id = vault_count;
+        vault_count += 1;
+        env.storage().instance().set(&DataKey::VaultCount, &vault_count);
+
         let vault = ProductivityVault {
-            creator: creator.clone(),
+            creator,
             amount,
             start_timestamp,
             end_timestamp,
@@ -57,7 +83,9 @@ impl DisciplrVault {
             failure_destination,
             status: VaultStatus::Active,
         };
-        let vault_id = 0u32; // placeholder; real impl would allocate id and persist
+        
+        env.storage().instance().set(&DataKey::Vault(vault_id), &vault);
+
         env.events().publish(
             (Symbol::new(&env, "vault_created"), vault_id),
             vault,
@@ -66,37 +94,195 @@ impl DisciplrVault {
     }
 
     /// Verifier (or authorized party) validates milestone completion.
-    pub fn validate_milestone(env: Env, vault_id: u32) -> bool {
-        // TODO: check vault exists, status is Active, caller is verifier, timestamp < end
-        // TODO: transfer USDC to success_destination, set status Completed
+    pub fn validate_milestone(env: Env, vault_id: u32) -> Result<bool, Error> {
+        let vault_key = DataKey::Vault(vault_id);
+        let mut vault: ProductivityVault = env
+            .storage()
+            .instance()
+            .get(&vault_key)
+            .ok_or(Error::VaultNotFound)?;
+
+        if vault.status != VaultStatus::Active {
+            return Err(Error::VaultNotActive);
+        }
+
+        // Auth check for verifier
+        if let Some(ref verifier) = vault.verifier {
+            verifier.require_auth();
+        } else {
+            vault.creator.require_auth();
+        }
+
+        // Timestamp check: rejects when current time >= end_timestamp
+        if env.ledger().timestamp() >= vault.end_timestamp {
+            return Err(Error::MilestoneExpired);
+        }
+
+        vault.status = VaultStatus::Completed;
+        env.storage().instance().set(&vault_key, &vault);
+
         env.events().publish(
             (Symbol::new(&env, "milestone_validated"), vault_id),
             (),
         );
-        true
+        Ok(true)
     }
 
-    /// Release funds to success destination (called after validation or by deadline logic).
-    pub fn release_funds(_env: Env, _vault_id: u32) -> bool {
-        // TODO: require status Active, transfer to success_destination, set Completed
-        true
+    /// Release funds to success destination.
+    pub fn release_funds(env: Env, vault_id: u32) -> Result<bool, Error> {
+        let vault_key = DataKey::Vault(vault_id);
+        let mut vault: ProductivityVault = env
+            .storage()
+            .instance()
+            .get(&vault_key)
+            .ok_or(Error::VaultNotFound)?;
+
+        if vault.status != VaultStatus::Active {
+            return Err(Error::VaultNotActive);
+        }
+
+        // Only allow release if validated (status would be Completed) or maybe this is a redundant method
+        // For now, let's just make it a stub that updates status if called.
+        // In a real impl, this would handle the actual USDC transfer.
+        vault.status = VaultStatus::Completed;
+        env.storage().instance().set(&vault_key, &vault);
+        Ok(true)
     }
 
     /// Redirect funds to failure destination (e.g. after deadline without validation).
-    pub fn redirect_funds(_env: Env, _vault_id: u32) -> bool {
-        // TODO: require status Active and past end_timestamp, transfer to failure_destination, set Failed
-        true
+    pub fn redirect_funds(env: Env, vault_id: u32) -> Result<bool, Error> {
+        let vault_key = DataKey::Vault(vault_id);
+        let mut vault: ProductivityVault = env
+            .storage()
+            .instance()
+            .get(&vault_key)
+            .ok_or(Error::VaultNotFound)?;
+
+        if vault.status != VaultStatus::Active {
+            return Err(Error::VaultNotActive);
+        }
+
+        if env.ledger().timestamp() < vault.end_timestamp {
+            return Err(Error::InvalidTimestamp); // Too early to redirect
+        }
+
+        vault.status = VaultStatus::Failed;
+        env.storage().instance().set(&vault_key, &vault);
+        Ok(true)
     }
 
-    /// Cancel vault and return funds to creator (if allowed by rules).
-    pub fn cancel_vault(_env: Env, _vault_id: u32) -> bool {
-        // TODO: require creator auth, return USDC to creator, set Cancelled
-        true
+    /// Cancel vault and return funds to creator.
+    pub fn cancel_vault(env: Env, vault_id: u32) -> Result<bool, Error> {
+        let vault_key = DataKey::Vault(vault_id);
+        let mut vault: ProductivityVault = env
+            .storage()
+            .instance()
+            .get(&vault_key)
+            .ok_or(Error::VaultNotFound)?;
+
+        vault.creator.require_auth();
+
+        if vault.status != VaultStatus::Active {
+            return Err(Error::VaultNotActive);
+        }
+
+        vault.status = VaultStatus::Cancelled;
+        env.storage().instance().set(&vault_key, &vault);
+        Ok(true)
     }
 
     /// Return current vault state for a given vault id.
-    /// Placeholder: returns None; full impl would read from storage.
-    pub fn get_vault_state(_env: Env, _vault_id: u32) -> Option<ProductivityVault> {
-        None
+    pub fn get_vault_state(env: Env, vault_id: u32) -> Option<ProductivityVault> {
+        env.storage().instance().get(&DataKey::Vault(vault_id))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+
+    #[test]
+    fn test_validate_milestone_rejects_after_end() {
+        let env = Env::default();
+        let contract_id = env.register(DisciplrVault, ());
+        let client = DisciplrVaultClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let verifier = Address::generate(&env);
+        let success_dest = Address::generate(&env);
+        let failure_dest = Address::generate(&env);
+
+        let start_time = 1000;
+        let end_time = 2000;
+        
+        env.ledger().set_timestamp(start_time);
+
+        // Sign for create_vault
+        env.mock_all_auths();
+
+        let vault_id = client.create_vault(
+            &creator,
+            &1000,
+            &start_time,
+            &end_time,
+            &BytesN::from_array(&env, &[0u8; 32]),
+            &Some(verifier.clone()),
+            &success_dest,
+            &failure_dest,
+        );
+
+        // Advance ledger to exactly end_timestamp
+        env.ledger().set_timestamp(end_time);
+
+        // Try to validate milestone - should fail with MilestoneExpired (error code 5)
+        // Try to validate milestone - should fail with MilestoneExpired
+        let _result = client.try_validate_milestone(&vault_id);
+        assert!(_result.is_err());
+
+        // Advance ledger past end_timestamp
+        env.ledger().set_timestamp(end_time + 1);
+
+        // Try to validate milestone - should also fail
+        let _result = client.try_validate_milestone(&vault_id);
+        assert!(_result.is_err());
+    }
+
+    #[test]
+    fn test_validate_milestone_succeeds_before_end() {
+        let env = Env::default();
+        let contract_id = env.register(DisciplrVault, ());
+        let client = DisciplrVaultClient::new(&env, &contract_id);
+
+        let creator = Address::generate(&env);
+        let verifier = Address::generate(&env);
+        let success_dest = Address::generate(&env);
+        let failure_dest = Address::generate(&env);
+
+        let start_time = 1000;
+        let end_time = 2000;
+        
+        env.ledger().set_timestamp(start_time);
+        env.mock_all_auths();
+
+        let vault_id = client.create_vault(
+            &creator,
+            &1000,
+            &start_time,
+            &end_time,
+            &BytesN::from_array(&env, &[0u8; 32]),
+            &Some(verifier.clone()),
+            &success_dest,
+            &failure_dest,
+        );
+
+        // Set time to just before end
+        env.ledger().set_timestamp(end_time - 1);
+
+        let success = client.validate_milestone(&vault_id);
+        assert!(success);
+
+        let vault = client.get_vault_state(&vault_id).unwrap();
+        assert_eq!(vault.status, VaultStatus::Completed);
     }
 }

--- a/test_snapshots/test/test_validate_milestone_rejects_after_end.1.json
+++ b/test_snapshots/test/test_validate_milestone_rejects_after_end.1.json
@@ -1,0 +1,257 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_vault",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                },
+                {
+                  "u64": 1000
+                },
+                {
+                  "u64": 2000
+                },
+                {
+                  "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 2001,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Vault"
+                            },
+                            {
+                              "u32": 0
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "amount"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 1000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "creator"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "end_timestamp"
+                              },
+                              "val": {
+                                "u64": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "failure_destination"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "milestone_hash"
+                              },
+                              "val": {
+                                "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "start_timestamp"
+                              },
+                              "val": {
+                                "u64": 1000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "status"
+                              },
+                              "val": {
+                                "u32": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "success_destination"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "verifier"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "VaultCount"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/test_snapshots/test/test_validate_milestone_succeeds_before_end.1.json
+++ b/test_snapshots/test/test_validate_milestone_succeeds_before_end.1.json
@@ -1,0 +1,308 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_vault",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                },
+                {
+                  "u64": 1000
+                },
+                {
+                  "u64": 2000
+                },
+                {
+                  "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "validate_milestone",
+              "args": [
+                {
+                  "u32": 0
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 1999,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Vault"
+                            },
+                            {
+                              "u32": 0
+                            }
+                          ]
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "amount"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 1000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "creator"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "end_timestamp"
+                              },
+                              "val": {
+                                "u64": 2000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "failure_destination"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "milestone_hash"
+                              },
+                              "val": {
+                                "bytes": "0000000000000000000000000000000000000000000000000000000000000000"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "start_timestamp"
+                              },
+                              "val": {
+                                "u64": 1000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "status"
+                              },
+                              "val": {
+                                "u32": 1
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "success_destination"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "verifier"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "VaultCount"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
# #23 Test validate_milestone rejects when current time >= end_timestamp
Closes #23
## Description
This PR implements the storage persistence layer and core logic for the [DisciplrVault](cci:2://file:///home/luckify/wave/Disciplr-Contracts/src/lib.rs:47:0-47:25) contract. It specifically addresses the requirement to ensure that milestone validation is strictly prohibited once the ledger timestamp reaches or exceeds the vault's `end_timestamp`.


## Key Changes

### 🛠 Core Implementation
- **Instance Storage**: Implemented a type-safe `DataKey` system to persist [ProductivityVault](cci:2://file:///home/luckify/wave/Disciplr-Contracts/src/lib.rs:27:0-37:1) data.
- **Vault Management**: Added [create_vault](cci:1://file:///home/luckify/wave/Disciplr-Contracts/src/lib.rs:51:4-93:5) logic with a global `VaultCount` for automated ID assignment.
- **State Guards**: Added status checks (must be `Active`) for all critical state transitions.

###  Security Enhancements
- **Timestamp Validation**: Added a strict check in [validate_milestone](cci:1://file:///home/luckify/wave/Disciplr-Contracts/src/lib.rs:95:4-128:5) that returns `Error::MilestoneExpired` if called at or after the deadline.
- **Authentication**: Implemented `require_auth()` for verifiers/creators to prevent unauthorized milestone validation.
- **Error Codes**: Introduced a custom `Error` enum for clearer debugging and integration.

### Testing
- **Expiration Test**: Added [test_validate_milestone_rejects_after_end](cci:1://file:///home/luckify/wave/Disciplr-Contracts/src/lib.rs:204:4-248:5) which simulates the ledger passing the deadline and asserts failure.
- **Success Test**: Added `test_validate_milestone_succeeds_before_end` to verify normal operation within the time window.

## Test Results
<img width="1030" height="216" alt="image" src="https://github.com/user-attachments/assets/fbde2d28-1568-45b3-b092-34af36ce0c06" />


<img width="1649" height="287" alt="image" src="https://github.com/user-attachments/assets/cc196fd1-a130-4344-9249-090ca8f3d14e" />

@1nonlypiece 

