### PR TITLE
test: create_vault emits vault_created and returns valid id (#17)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,3 +100,122 @@ impl DisciplrVault {
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    extern crate std; // no_std crate — explicitly link std for the test harness
+
+    use super::*;
+    use soroban_sdk::{
+        testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Events},
+        Address, BytesN, Env, IntoVal, Symbol, TryIntoVal,
+    };
+
+    /// Helper: build a default set of valid vault parameters.
+    fn make_vault_args(
+        env: &Env,
+    ) -> (Address, i128, u64, u64, BytesN<32>, Option<Address>, Address, Address) {
+        let creator        = Address::generate(env);
+        let success_dest   = Address::generate(env);
+        let failure_dest   = Address::generate(env);
+        let verifier       = Address::generate(env);
+        let milestone_hash = BytesN::from_array(env, &[1u8; 32]);
+        let amount         = 1_000_000i128; // 1 USDC (6 decimals)
+        let start          = 1_000_000u64;
+        let end            = 2_000_000u64;
+
+        (creator, amount, start, end, milestone_hash, Some(verifier), success_dest, failure_dest)
+    }
+
+    /// create_vault must:
+    ///   1. return a vault_id (currently the placeholder 0u32)
+    ///   2. require creator authorisation
+    ///   3. emit exactly one `vault_created` event carrying that vault_id
+    #[test]
+    fn test_create_vault_emits_event_and_returns_id() {
+        let env = Env::default();
+        env.mock_all_auths(); // satisfies creator.require_auth()
+
+        let contract_id = env.register(DisciplrVault, ());
+        let client      = DisciplrVaultClient::new(&env, &contract_id);
+
+        let (creator, amount, start_timestamp, end_timestamp,
+             milestone_hash, verifier, success_destination, failure_destination) =
+            make_vault_args(&env);
+
+        // ── Invoke ───────────────────────────────────────────────────────────
+        let vault_id = client.create_vault(
+            &creator,
+            &amount,
+            &start_timestamp,
+            &end_timestamp,
+            &milestone_hash,
+            &verifier,
+            &success_destination,
+            &failure_destination,
+        );
+
+        // ── Assert: return value ─────────────────────────────────────────────
+        // Returns 0u32 as a placeholder; update when real ID allocation lands.
+        assert_eq!(vault_id, 0u32, "vault_id should be the placeholder 0");
+
+        // ── Assert: auth was required for creator ────────────────────────────
+        let auths = env.auths();
+        assert_eq!(auths.len(), 1, "exactly one auth should be recorded");
+        assert_eq!(
+            auths[0],
+            (
+                creator.clone(),
+                AuthorizedInvocation {
+                    function: AuthorizedFunction::Contract((
+                        contract_id.clone(),
+                        Symbol::new(&env, "create_vault"),
+                        (
+                            creator.clone(),
+                            amount,
+                            start_timestamp,
+                            end_timestamp,
+                            milestone_hash.clone(),
+                            verifier.clone(),
+                            success_destination.clone(),
+                            failure_destination.clone(),
+                        )
+                            .into_val(&env),
+                    )),
+                    sub_invocations: std::vec![], // std linked above via extern crate
+                }
+            )
+        );
+
+        // ── Assert: vault_created event was emitted ──────────────────────────
+        let all_events = env.events().all();
+        assert_eq!(all_events.len(), 1, "exactly one event should be emitted");
+
+        let (emitting_contract, topics, _data) = all_events.get(0).unwrap();
+        assert_eq!(emitting_contract, contract_id, "event must come from the vault contract");
+
+        // topics[0] = Symbol("vault_created"), topics[1] = vault_id
+        let event_name: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+        let event_vault_id: u32 = topics.get(1).unwrap().try_into_val(&env).unwrap();
+
+        assert_eq!(event_name, Symbol::new(&env, "vault_created"), "event name must be vault_created");
+        assert_eq!(event_vault_id, vault_id, "event vault_id must match the returned vault_id");
+    }
+
+    /// Documents expected timestamp validation behaviour.
+    /// Marked #[ignore] until the contract enforces end > start.
+    #[test]
+    #[ignore = "validation not yet implemented in create_vault"]
+    fn test_create_vault_rejects_invalid_timestamps() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(DisciplrVault, ());
+        let client      = DisciplrVaultClient::new(&env, &contract_id);
+
+        let (creator, amount, start, _, hash, verifier, s_dest, f_dest) = make_vault_args(&env);
+
+        // end == start — should panic once validation is added
+        client.create_vault(&creator, &amount, &start, &start, &hash, &verifier, &s_dest, &f_dest);
+    }
+}

--- a/test_snapshots/tests/test_create_vault_emits_event_and_returns_id.1.json
+++ b/test_snapshots/tests/test_create_vault_emits_event_and_returns_id.1.json
@@ -1,0 +1,251 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_vault",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000000
+                  }
+                },
+                {
+                  "u64": 1000000
+                },
+                {
+                  "u64": 2000000
+                },
+                {
+                  "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "vault_created"
+              },
+              {
+                "u32": 0
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "amount"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 1000000
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "creator"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "end_timestamp"
+                  },
+                  "val": {
+                    "u64": 2000000
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "failure_destination"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "milestone_hash"
+                  },
+                  "val": {
+                    "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "start_timestamp"
+                  },
+                  "val": {
+                    "u64": 1000000
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "status"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "success_destination"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "verifier"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}


### PR DESCRIPTION
Closes #17

## Changes

Added `#[cfg(test)]` module to `src/lib.rs` with two tests:

- **`test_create_vault_emits_event_and_returns_id`** — calls `create_vault` with valid parameters, asserts `creator.require_auth()` was enforced, asserts exactly one `vault_created` event is emitted with the correct vault_id in topics, and asserts the returned `vault_id` matches
- **`test_create_vault_rejects_invalid_timestamps`** — documents expected validation behaviour (end ≤ start should be rejected); marked `#[ignore]` since that guard isn't implemented yet

## Test output

```
cargo test
running 2 tests
test tests::test_create_vault_rejects_invalid_timestamps ... ignored (validation not yet implemented in create_vault)
test tests::test_create_vault_emits_event_and_returns_id ... ok

test result: ok. 1 passed; 0 failed; 1 ignored
```