### PR TITLE
Allow permissionless release after deadline

### DIFF
--- a/docs/RELEASE_AUTH.md
+++ b/docs/RELEASE_AUTH.md
@@ -1,0 +1,23 @@
+# Release Authorization
+
+`release_funds` sends the locked vault balance only to the vault's stored
+`success_destination`. The caller does not provide a destination, so triggering a
+release cannot redirect funds to the caller or another address.
+
+## Authorization Matrix
+
+| Vault state | Release condition | Required caller |
+| --- | --- | --- |
+| Active, before `end_timestamp`, not validated | Rejected with `Error::NotAuthorized` | None |
+| Active, before `end_timestamp`, validated | Allowed | Any caller |
+| Active, at or after `end_timestamp` | Allowed | Any caller |
+| Completed, Failed, or Cancelled | Rejected with `Error::VaultNotActive` | None |
+
+Milestone validation remains restricted: the configured verifier must validate
+when `verifier` is `Some`, and the creator must validate when `verifier` is
+`None`. Once that validation has been recorded, `release_funds` only checks the
+vault state and destination invariants before transferring to `success_destination`.
+
+This keeps the post-deadline path permissionless. If the creator disappears,
+any account can still trigger the success transfer after the deadline, while the
+funds remain bound to the pre-committed destination.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -845,6 +845,15 @@ mod tests {
         // Success destination received the funds.
         let success_after = usdc.balance(&setup.success_dest);
         assert_eq!(success_after - success_before, setup.amount);
+        assert!(
+            !recorded_auth_for(
+                &setup.env,
+                &setup.creator,
+                &setup.contract_id,
+                "release_funds"
+            ),
+            "validated pre-deadline release must not require creator authorization"
+        );
 
         // Vault status is Completed.
         let vault = client.get_vault_state(&vault_id).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,6 +254,13 @@ impl DisciplrVault {
     // -----------------------------------------------------------------------
 
     /// Release vault funds to `success_destination`.
+    ///
+    /// Authorization matrix:
+    /// - Before `end_timestamp`, the milestone must have been validated by the configured verifier
+    ///   or, when no verifier is configured, by the creator.
+    /// - At or after `end_timestamp`, anyone may trigger release because the destination is fixed
+    ///   to the pre-committed `success_destination`.
+    /// - Callers can never redirect release funds to themselves or any supplied address.
     pub fn release_funds(env: Env, vault_id: u32, usdc_token: Address) -> Result<bool, Error> {
         let vault_key = DataKey::Vault(vault_id);
         let mut vault: ProductivityVault = env
@@ -261,8 +268,6 @@ impl DisciplrVault {
             .instance()
             .get(&vault_key)
             .ok_or(Error::VaultNotFound)?;
-
-        vault.creator.require_auth();
 
         if vault.status != VaultStatus::Active {
             return Err(Error::VaultNotActive); // Or InvalidStatus as appropriate
@@ -510,6 +515,25 @@ mod tests {
                 &self.failure_dest,
             )
         }
+    }
+
+    fn recorded_auth_for(
+        env: &Env,
+        address: &Address,
+        contract_id: &Address,
+        function_name: &str,
+    ) -> bool {
+        env.auths().into_iter().any(|(auth_addr, invocation)| {
+            if &auth_addr != address {
+                return false;
+            }
+            match invocation.function {
+                AuthorizedFunction::Contract((contract, symbol, _)) => {
+                    &contract == contract_id && symbol == Symbol::new(env, function_name)
+                }
+                _ => false,
+            }
+        })
     }
 
     // -----------------------------------------------------------------------
@@ -845,9 +869,42 @@ mod tests {
         assert!(result);
 
         assert_eq!(usdc.balance(&setup.success_dest) - before, setup.amount);
+        assert!(
+            !recorded_auth_for(
+                &setup.env,
+                &setup.creator,
+                &setup.contract_id,
+                "release_funds"
+            ),
+            "post-deadline release must not require creator authorization"
+        );
 
         let vault = client.get_vault_state(&vault_id).unwrap();
         assert_eq!(vault.status, VaultStatus::Completed);
+    }
+
+    #[test]
+    fn test_release_funds_after_deadline_uses_fixed_success_destination() {
+        let setup = TestSetup::new();
+        let client = setup.client();
+
+        setup.env.ledger().set_timestamp(setup.start_timestamp);
+        let vault_id = setup.create_default_vault();
+        setup.env.ledger().set_timestamp(setup.end_timestamp + 1);
+
+        let usdc = setup.usdc_client();
+        let creator_before = usdc.balance(&setup.creator);
+        let success_before = usdc.balance(&setup.success_dest);
+        let failure_before = usdc.balance(&setup.failure_dest);
+
+        assert!(client.release_funds(&vault_id, &setup.usdc_token));
+
+        assert_eq!(
+            usdc.balance(&setup.success_dest) - success_before,
+            setup.amount
+        );
+        assert_eq!(usdc.balance(&setup.creator), creator_before);
+        assert_eq!(usdc.balance(&setup.failure_dest), failure_before);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- remove the unconditional creator authorization gate from release_funds
- document the release authorization matrix and fixed success_destination invariant
- add tests covering post-deadline release without creator release auth and fixed-destination transfer behavior

Closes #235

## Validation
- git diff --check
- cargo fmt -- --check
- conflict-marker scan