### PR TITLE
test: cover release funds balance flow

### DIFF
--- a/COVERAGE_ANALYSIS.md
+++ b/COVERAGE_ANALYSIS.md
@@ -101,6 +101,15 @@ According to [smart contract testing best practices](https://moldstud.com/articl
 - Cancellation events
 - Initial status verification
 
+**Release Funds Balance Flow (Issue #226):**
+
+- Validated release path asserts the contract escrow balance is debited by exactly `vault.amount`
+- Deadline release path asserts `success_destination` is credited by exactly `vault.amount`
+- Creator balance is checked before and after release to prove release does not debit the creator twice
+- Post-release contract balance reaches zero for a fully funded vault
+- Double-release rejection preserves contract, creator, and `success_destination` balances
+- `funds_released` event coverage verifies the vault id topic and exact amount payload via `env.events()`
+
 **Data Integrity & Edge Cases (10 tests):**
 
 - Vault creation with verifier

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -87,6 +87,26 @@ Verifies audit trail logging:
 cargo test test_.*_emits_event
 ```
 
+### 3a. Release Funds Balance Flow (Issue #226)
+
+Focused lifecycle coverage proves exact USDC movement for `release_funds`:
+
+```bash
+cargo test --test lifecycle test_full_lifecycle_success
+cargo test --test lifecycle test_release_funds_after_deadline_moves_exact_balance
+cargo test --test lifecycle test_double_release_rejection_preserves_balances
+cargo test test_release_funds_emits_event_with_amount
+```
+
+What is validated:
+
+- Validated-before-deadline release debits the contract address by exactly `vault.amount`.
+- Deadline-based release credits `success_destination` by exactly `vault.amount`.
+- The creator balance is unchanged during release because the escrow debit already happened at vault creation.
+- The contract balance reaches zero after a full release.
+- A second release attempt is rejected and leaves contract, creator, and `success_destination` balances unchanged.
+- `funds_released` is emitted with the vault id topic and exact released amount.
+
 ### 4. Data Integrity (10 tests)
 
 Edge cases and comprehensive validation:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -851,6 +851,43 @@ mod tests {
     }
 
     #[test]
+    fn test_release_funds_emits_event_with_amount() {
+        let setup = TestSetup::new();
+        let client = setup.client();
+
+        setup.env.ledger().set_timestamp(setup.start_timestamp);
+        let vault_id = setup.create_default_vault();
+        setup.env.ledger().set_timestamp(setup.end_timestamp);
+
+        assert!(client.release_funds(&vault_id, &setup.usdc_token));
+
+        let event_name = Symbol::new(&setup.env, "funds_released");
+        let found = setup
+            .env
+            .events()
+            .all()
+            .into_iter()
+            .any(|(emitter, topics, data)| {
+                if emitter != setup.contract_id {
+                    return false;
+                }
+
+                let topic_name: Symbol = topics.get(0).unwrap().try_into_val(&setup.env).unwrap();
+                let event_vault_id: u32 = topics.get(1).unwrap().try_into_val(&setup.env).unwrap();
+                let event_amount: i128 = data.try_into_val(&setup.env).unwrap();
+
+                topic_name == event_name
+                    && event_vault_id == vault_id
+                    && event_amount == setup.amount
+            });
+
+        assert!(
+            found,
+            "funds_released event must include vault id and amount"
+        );
+    }
+
+    #[test]
     fn test_double_release_rejected() {
         let setup = TestSetup::new();
         let client = setup.client();

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -12,6 +12,7 @@ fn setup() -> (
     Env,
     DisciplrVaultClient<'static>,
     Address,
+    Address,
     StellarAssetClient<'static>,
     TokenClient<'static>,
 ) {
@@ -27,12 +28,19 @@ fn setup() -> (
     let usdc_asset = StellarAssetClient::new(&env, &usdc_addr);
     let usdc_token_client = TokenClient::new(&env, &usdc_addr);
 
-    (env, client, usdc_addr, usdc_asset, usdc_token_client)
+    (
+        env,
+        client,
+        contract_id,
+        usdc_addr,
+        usdc_asset,
+        usdc_token_client,
+    )
 }
 
 #[test]
 fn test_full_lifecycle_success() {
-    let (env, client, usdc, usdc_asset, usdc_token) = setup();
+    let (env, client, contract_id, usdc, usdc_asset, usdc_token) = setup();
 
     let creator = Address::generate(&env);
     let verifier = Address::generate(&env);
@@ -74,15 +82,110 @@ fn test_full_lifecycle_success() {
     );
 
     // 3. Release Funds
+    let contract_before = usdc_token.balance(&contract_id);
+    let creator_before = usdc_token.balance(&creator);
+    let success_before = usdc_token.balance(&success_dest);
     client.release_funds(&vault_id, &usdc);
     let final_state = client.get_vault_state(&vault_id).unwrap();
     assert_eq!(final_state.status, VaultStatus::Completed);
-    assert_eq!(usdc_token.balance(&success_dest), MIN_AMOUNT);
+
+    assert_eq!(contract_before, MIN_AMOUNT);
+    assert_eq!(
+        usdc_token.balance(&contract_id),
+        contract_before - MIN_AMOUNT
+    );
+    assert_eq!(usdc_token.balance(&creator), creator_before);
+    assert_eq!(
+        usdc_token.balance(&success_dest),
+        success_before + MIN_AMOUNT
+    );
+}
+
+#[test]
+fn test_release_funds_after_deadline_moves_exact_balance() {
+    let (env, client, contract_id, usdc, usdc_asset, usdc_token) = setup();
+
+    let creator = Address::generate(&env);
+    let success_dest = Address::generate(&env);
+    let failure_dest = Address::generate(&env);
+    let now = 1_700_000_000u64;
+    env.ledger().set_timestamp(now);
+
+    usdc_asset.mint(&creator, &MIN_AMOUNT);
+
+    let milestone = BytesN::from_array(&env, &[2u8; 32]);
+    let vault_id = client.create_vault(
+        &usdc,
+        &creator,
+        &MIN_AMOUNT,
+        &now,
+        &(now + 86_400),
+        &milestone,
+        &None,
+        &success_dest,
+        &failure_dest,
+    );
+
+    env.ledger().set_timestamp(now + 86_400);
+
+    let contract_before = usdc_token.balance(&contract_id);
+    let creator_before = usdc_token.balance(&creator);
+    let success_before = usdc_token.balance(&success_dest);
+
+    client.release_funds(&vault_id, &usdc);
+
+    let final_state = client.get_vault_state(&vault_id).unwrap();
+    assert_eq!(final_state.status, VaultStatus::Completed);
+    assert_eq!(contract_before, MIN_AMOUNT);
+    assert_eq!(usdc_token.balance(&contract_id), 0);
+    assert_eq!(usdc_token.balance(&creator), creator_before);
+    assert_eq!(
+        usdc_token.balance(&success_dest),
+        success_before + MIN_AMOUNT
+    );
+}
+
+#[test]
+fn test_double_release_rejection_preserves_balances() {
+    let (env, client, contract_id, usdc, usdc_asset, usdc_token) = setup();
+
+    let creator = Address::generate(&env);
+    let success_dest = Address::generate(&env);
+    let failure_dest = Address::generate(&env);
+    let now = 1_700_000_000u64;
+    env.ledger().set_timestamp(now);
+
+    usdc_asset.mint(&creator, &MIN_AMOUNT);
+
+    let milestone = BytesN::from_array(&env, &[3u8; 32]);
+    let vault_id = client.create_vault(
+        &usdc,
+        &creator,
+        &MIN_AMOUNT,
+        &now,
+        &(now + 86_400),
+        &milestone,
+        &None,
+        &success_dest,
+        &failure_dest,
+    );
+
+    env.ledger().set_timestamp(now + 86_400);
+    client.release_funds(&vault_id, &usdc);
+
+    let contract_after_release = usdc_token.balance(&contract_id);
+    let creator_after_release = usdc_token.balance(&creator);
+    let success_after_release = usdc_token.balance(&success_dest);
+
+    assert!(client.try_release_funds(&vault_id, &usdc).is_err());
+    assert_eq!(usdc_token.balance(&contract_id), contract_after_release);
+    assert_eq!(usdc_token.balance(&creator), creator_after_release);
+    assert_eq!(usdc_token.balance(&success_dest), success_after_release);
 }
 
 #[test]
 fn test_full_lifecycle_failure_redirection() {
-    let (env, client, usdc, usdc_asset, usdc_token) = setup();
+    let (env, client, _contract_id, usdc, usdc_asset, usdc_token) = setup();
 
     let creator = Address::generate(&env);
     let success_dest = Address::generate(&env);

--- a/tests/proptest_timestamps.rs
+++ b/tests/proptest_timestamps.rs
@@ -279,7 +279,6 @@ fn edge_start_eq_now_succeeds() {
     assert_eq!(vault.end_timestamp, end);
 }
 
-
 #[test]
 fn edge_start_eq_end_rejected() {
     let (env, client, usdc, usdc_asset) = setup();


### PR DESCRIPTION
## Summary
- add lifecycle coverage for validated and deadline release_funds paths with exact contract, creator, and success destination balance assertions
- add double-release rejection coverage proving balances are unchanged after the failed second release
- add funds_released event coverage for vault id and amount via env.events()
- document the new Issue #226 release-flow coverage in the testing and coverage docs

Closes #226

## Validation
- cargo fmt --check
- cargo test
- git diff --check

Note: local cargo tarpaulin --config tarpaulin.toml --out Stdout could not run because this environment does not have cargo-tarpaulin installed; the repository coverage workflow should run it in CI.