### PR TITLE
feat: add paginated list_vaults view

### DIFF
--- a/docs/LIST_VAULTS.md
+++ b/docs/LIST_VAULTS.md
@@ -1,0 +1,33 @@
+# Paginated Vault Enumeration
+
+`list_vaults(start_id, limit)` is a read-only enumeration view for frontends and
+indexers that need to fetch vault records without probing every ID one call at a
+time.
+
+## Contract
+
+```rust
+pub fn list_vaults(
+    env: Env,
+    start_id: u32,
+    limit: u32,
+) -> Result<Vec<(u32, ProductivityVault)>, Error>
+```
+
+## Behavior
+
+- Returns existing `(vault_id, ProductivityVault)` records in the half-open range
+  `[start_id, start_id + limit)`.
+- Stops at `vault_count()` so it does not read beyond the assigned ID range.
+- Skips missing records gracefully.
+- Requires no authorization and does not mutate storage.
+- Allows `limit = 0`, which returns an empty page.
+- Rejects `limit > MAX_LIST_VAULTS_LIMIT` with `Error::LimitTooLarge`.
+
+The current maximum page size is `100` records.
+
+## Example
+
+To enumerate every vault, callers can start at `0`, request at most
+`MAX_LIST_VAULTS_LIMIT` records, and continue with the next start ID until an
+empty page is returned or `vault_count()` has been reached.

--- a/src/doc.md
+++ b/src/doc.md
@@ -29,6 +29,7 @@ This guide provides comprehensive documentation for backend developers integrati
 | `redirect_funds` | POST | `/api/v1/vaults/{vault_id}/redirect` | Redirect funds to failure destination |
 | `cancel_vault` | POST | `/api/v1/vaults/{vault_id}/cancel` | Cancel vault and return funds |
 | `get_vault_state` | GET | `/api/v1/vaults/{vault_id}` | Query vault state |
+| `list_vaults` | GET | `/api/v1/vaults?start_id={start_id}&limit={limit}` | List a bounded page of vaults |
 | `vault_count` | GET | `/api/v1/vaults/count` | Get total vault count |
 
 ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::too_many_arguments)]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, token, Address, BytesN, Env, Symbol,
+    contract, contracterror, contractimpl, contracttype, token, Address, BytesN, Env, Symbol, Vec,
 };
 
 // ---------------------------------------------------------------------------
@@ -37,6 +37,8 @@ pub enum Error {
     InvalidTimestamps = 8,
     /// Vault duration (end − start) exceeds MAX_VAULT_DURATION.
     DurationTooLong = 9,
+    /// Requested pagination window exceeds the maximum read limit.
+    LimitTooLarge = 10,
 }
 
 // ---------------------------------------------------------------------------
@@ -107,6 +109,9 @@ pub const MIN_AMOUNT: i128 = 10_000_000; // 1 USDC
 /// Enforced in `create_vault`: `amount` must be ≤ `MAX_AMOUNT`,
 /// otherwise returns `Error::InvalidAmount`.
 pub const MAX_AMOUNT: i128 = 10_000_000_000_000; // 10M USDC
+
+/// Maximum records returned by `list_vaults` in a single read-only call.
+pub const MAX_LIST_VAULTS_LIMIT: u32 = 100;
 
 #[contracttype]
 #[derive(Clone)]
@@ -386,6 +391,35 @@ impl DisciplrVault {
     /// observed, but the contract itself has no path that deletes vault records.
     pub fn get_vault_state(env: Env, vault_id: u32) -> Option<ProductivityVault> {
         env.storage().instance().get(&DataKey::Vault(vault_id))
+    }
+
+    /// Return a bounded page of existing vault records starting at `start_id`.
+    ///
+    /// The returned vector contains `(vault_id, ProductivityVault)` pairs for
+    /// existing records in `[start_id, start_id + limit)`. Missing IDs are
+    /// skipped and `limit` must be at most `MAX_LIST_VAULTS_LIMIT`.
+    pub fn list_vaults(
+        env: Env,
+        start_id: u32,
+        limit: u32,
+    ) -> Result<Vec<(u32, ProductivityVault)>, Error> {
+        if limit > MAX_LIST_VAULTS_LIMIT {
+            return Err(Error::LimitTooLarge);
+        }
+
+        let vault_count = Self::vault_count(env.clone());
+        let end_id = start_id.saturating_add(limit).min(vault_count);
+        let mut vaults = Vec::new(&env);
+        let mut id = start_id;
+
+        while id < end_id {
+            if let Some(vault) = env.storage().instance().get(&DataKey::Vault(id)) {
+                vaults.push_back((id, vault));
+            }
+            id += 1;
+        }
+
+        Ok(vaults)
     }
 
     /// Return the number of vault IDs assigned so far.

--- a/tests/list_vaults.rs
+++ b/tests/list_vaults.rs
@@ -1,0 +1,134 @@
+#![cfg(test)]
+
+use disciplr_vault::{
+    DisciplrVault, DisciplrVaultClient, Error, VaultStatus, MAX_LIST_VAULTS_LIMIT, MIN_AMOUNT,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::StellarAssetClient,
+    Address, BytesN, Env,
+};
+
+fn setup() -> (
+    Env,
+    DisciplrVaultClient<'static>,
+    Address,
+    StellarAssetClient<'static>,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_700_000_000);
+
+    let contract_id = env.register(DisciplrVault, ());
+    let client = DisciplrVaultClient::new(&env, &contract_id);
+
+    let usdc_admin = Address::generate(&env);
+    let usdc_token = env.register_stellar_asset_contract_v2(usdc_admin.clone());
+    let usdc_addr = usdc_token.address();
+    let usdc_asset = StellarAssetClient::new(&env, &usdc_addr);
+
+    (env, client, usdc_addr, usdc_asset)
+}
+
+fn create_vault(
+    env: &Env,
+    client: &DisciplrVaultClient<'_>,
+    usdc: &Address,
+    usdc_asset: &StellarAssetClient<'_>,
+    start_offset: u64,
+) -> u32 {
+    let creator = Address::generate(env);
+    let success = Address::generate(env);
+    let failure = Address::generate(env);
+    let now = env.ledger().timestamp();
+    let start = now + start_offset;
+    let end = start + 86_400;
+
+    usdc_asset.mint(&creator, &MIN_AMOUNT);
+    client.create_vault(
+        usdc,
+        &creator,
+        &MIN_AMOUNT,
+        &start,
+        &end,
+        &BytesN::from_array(env, &[start_offset as u8; 32]),
+        &None,
+        &success,
+        &failure,
+    )
+}
+
+fn assert_contract_error<T: core::fmt::Debug>(
+    result: Result<T, Result<Error, soroban_sdk::InvokeError>>,
+    expected: Error,
+) {
+    match result {
+        Err(Ok(actual)) => assert_eq!(actual, expected),
+        other => panic!("unexpected result: {other:?}"),
+    }
+}
+
+#[test]
+fn list_vaults_empty_and_zero_limit_return_empty_pages() {
+    let (_env, client, _usdc, _usdc_asset) = setup();
+
+    assert_eq!(client.list_vaults(&0, &10).len(), 0);
+    assert_eq!(client.list_vaults(&0, &0).len(), 0);
+}
+
+#[test]
+fn list_vaults_returns_partial_window_with_ids() {
+    let (env, client, usdc, usdc_asset) = setup();
+    let first = create_vault(&env, &client, &usdc, &usdc_asset, 10);
+    let second = create_vault(&env, &client, &usdc, &usdc_asset, 20);
+    let third = create_vault(&env, &client, &usdc, &usdc_asset, 30);
+
+    assert_eq!(first, 0);
+    assert_eq!(second, 1);
+    assert_eq!(third, 2);
+
+    let page = client.list_vaults(&1, &2);
+    assert_eq!(page.len(), 2);
+
+    let (id_1, vault_1) = page.get(0).unwrap();
+    let (id_2, vault_2) = page.get(1).unwrap();
+    assert_eq!(id_1, second);
+    assert_eq!(id_2, third);
+    assert_eq!(vault_1.status, VaultStatus::Active);
+    assert_eq!(vault_2.status, VaultStatus::Active);
+}
+
+#[test]
+fn list_vaults_start_beyond_count_returns_empty_page() {
+    let (env, client, usdc, usdc_asset) = setup();
+    create_vault(&env, &client, &usdc, &usdc_asset, 10);
+
+    assert_eq!(client.list_vaults(&99, &10).len(), 0);
+}
+
+#[test]
+fn list_vaults_rejects_limit_over_cap() {
+    let (_env, client, _usdc, _usdc_asset) = setup();
+    let result = client.try_list_vaults(&0, &(MAX_LIST_VAULTS_LIMIT + 1));
+
+    assert_contract_error(result, Error::LimitTooLarge);
+}
+
+#[test]
+fn list_vaults_includes_terminal_vaults() {
+    let (env, client, usdc, usdc_asset) = setup();
+    let completed = create_vault(&env, &client, &usdc, &usdc_asset, 10);
+    let failed = create_vault(&env, &client, &usdc, &usdc_asset, 20);
+    let cancelled = create_vault(&env, &client, &usdc, &usdc_asset, 30);
+
+    env.ledger().set_timestamp(1_700_000_000 + 30 + 86_401);
+    client.release_funds(&completed, &usdc);
+    client.redirect_funds(&failed, &usdc);
+    client.cancel_vault(&cancelled, &usdc);
+
+    let page = client.list_vaults(&0, &MAX_LIST_VAULTS_LIMIT);
+    assert_eq!(page.len(), 3);
+    assert_eq!(page.get(0).unwrap().1.status, VaultStatus::Completed);
+    assert_eq!(page.get(1).unwrap().1.status, VaultStatus::Failed);
+    assert_eq!(page.get(2).unwrap().1.status, VaultStatus::Cancelled);
+}

--- a/tests/proptest_timestamps.rs
+++ b/tests/proptest_timestamps.rs
@@ -279,7 +279,6 @@ fn edge_start_eq_now_succeeds() {
     assert_eq!(vault.end_timestamp, end);
 }
 
-
 #[test]
 fn edge_start_eq_end_rejected() {
     let (env, client, usdc, usdc_asset) = setup();


### PR DESCRIPTION
## Summary
- adds bounded read-only list_vaults(start_id, limit) returning (vault_id, ProductivityVault) records
- rejects pages above MAX_LIST_VAULTS_LIMIT with Error::LimitTooLarge
- covers empty, zero-limit, partial, beyond-count, over-limit, and terminal-vault windows
- documents the pagination contract and API mapping

Closes #223

## Validation
- cargo fmt --check
- git diff --check
- cargo test