### PR TITLE
feat: standardize vault lifecycle events

### DIFF
--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -1,0 +1,29 @@
+# Disciplr Vault Event Schema
+
+Lifecycle events use stable names with a consistent indexed topic layout:
+
+```text
+(event_name, vault_id, creator)
+```
+
+The event data is always `VaultLifecycleEventData`:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `amount` | `i128` | Vault amount in the token's smallest unit. |
+| `destination` | `Option<Address>` | Destination affected by the transition, when one exists. |
+| `status` | `VaultStatus` | Vault status after the transition. |
+
+## Lifecycle Events
+
+| Event | Topics | Data |
+| --- | --- | --- |
+| `vault_created` | `("vault_created", vault_id, creator)` | `{ amount, destination: None, status: Active }` |
+| `milestone_validated` | `("milestone_validated", vault_id, creator)` | `{ amount, destination: None, status: Active }` |
+| `funds_released` | `("funds_released", vault_id, creator)` | `{ amount, destination: Some(success_destination), status: Completed }` |
+| `funds_redirected` | `("funds_redirected", vault_id, creator)` | `{ amount, destination: Some(failure_destination), status: Failed }` |
+| `vault_cancelled` | `("vault_cancelled", vault_id, creator)` | `{ amount, destination: Some(creator), status: Cancelled }` |
+
+Event names are unchanged for backward compatibility. Consumers that previously
+filtered by `(event_name, vault_id)` can keep using those first two topics, while
+new consumers can filter by the third `creator` topic without decoding payloads.

--- a/src/doc.md
+++ b/src/doc.md
@@ -598,13 +598,17 @@ All transactions benefit from Stellar's built-in replay protection via sequence 
 
 ### Contract Events
 
+Lifecycle events keep their existing event names and use a consistent indexed
+topic tuple: `(event_name, vault_id, creator)`. The data payload is always
+`VaultLifecycleEventData { amount, destination, status }`.
+
 | Event | Topic | Data | Trigger |
 |-------|-------|------|---------|
-| `vault_created` | `("vault_created", vault_id)` | `ProductivityVault` | Vault creation |
-| `milestone_validated` | `("milestone_validated", vault_id)` | `()` | Successful validation |
-| `funds_released` | `("funds_released", vault_id)` | `amount: i128` | Fund release |
-| `funds_redirected` | `("funds_redirected", vault_id)` | `amount: i128` | Fund redirect |
-| `vault_cancelled` | `("vault_cancelled", vault_id)` | `()` | Vault cancellation |
+| `vault_created` | `("vault_created", vault_id, creator)` | `{ amount, destination: None, status: Active }` | Vault creation |
+| `milestone_validated` | `("milestone_validated", vault_id, creator)` | `{ amount, destination: None, status: Active }` | Successful validation |
+| `funds_released` | `("funds_released", vault_id, creator)` | `{ amount, destination: Some(success_destination), status: Completed }` | Fund release |
+| `funds_redirected` | `("funds_redirected", vault_id, creator)` | `{ amount, destination: Some(failure_destination), status: Failed }` | Fund redirect |
+| `vault_cancelled` | `("vault_cancelled", vault_id, creator)` | `{ amount, destination: Some(creator), status: Cancelled }` | Vault cancellation |
 
 ### Event Subscription Pattern
 
@@ -613,11 +617,11 @@ class EventMonitor {
   async subscribeToVaultEvents(vaultId: number): Promise<void> {
     const filter = {
       topics: [
-        ['vault_created', vaultId.toString()],
-        ['milestone_validated', vaultId.toString()],
-        ['funds_released', vaultId.toString()],
-        ['funds_redirected', vaultId.toString()],
-        ['vault_cancelled', vaultId.toString()]
+        ['vault_created', vaultId.toString(), creatorAddress],
+        ['milestone_validated', vaultId.toString(), creatorAddress],
+        ['funds_released', vaultId.toString(), creatorAddress],
+        ['funds_redirected', vaultId.toString(), creatorAddress],
+        ['vault_cancelled', vaultId.toString(), creatorAddress]
       ]
     };
     
@@ -630,10 +634,15 @@ class EventMonitor {
   private handleVaultEvent(vaultId: number, event: SorobanEvent): void {
     switch (event.topic[0]) {
       case 'milestone_validated':
-        this.emit('milestoneValidated', { vaultId });
+        this.emit('milestoneValidated', { vaultId, status: event.data.status });
         break;
       case 'funds_released':
-        this.emit('fundsReleased', { vaultId, amount: event.data });
+        this.emit('fundsReleased', {
+          vaultId,
+          amount: event.data.amount,
+          destination: event.data.destination,
+          status: event.data.status
+        });
         break;
       // ... handle other events
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,19 @@ pub struct ProductivityVault {
     pub milestone_validated: bool,
 }
 
+/// Typed payload emitted by every vault lifecycle event.
+///
+/// Topics are always `(event_name, vault_id, creator)`. Data carries the
+/// vault amount, the destination affected by the transition when there is one,
+/// and the status after the transition.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VaultLifecycleEventData {
+    pub amount: i128,
+    pub destination: Option<Address>,
+    pub status: VaultStatus,
+}
+
 // ---------------------------------------------------------------------------
 // Storage keys
 // ---------------------------------------------------------------------------
@@ -184,7 +197,7 @@ impl DisciplrVault {
             .instance()
             .set(&DataKey::VaultCount, &vault_count);
         let vault = ProductivityVault {
-            creator,
+            creator: creator.clone(),
             amount,
             start_timestamp,
             end_timestamp,
@@ -200,9 +213,14 @@ impl DisciplrVault {
             .instance()
             .set(&DataKey::Vault(vault_id), &vault);
 
+        // Emitted when a new vault is funded and stored.
         env.events().publish(
-            (Symbol::new(&env, "vault_created"), vault_id),
-            vault.clone(),
+            (Symbol::new(&env, "vault_created"), vault_id, creator),
+            VaultLifecycleEventData {
+                amount: vault.amount,
+                destination: None,
+                status: vault.status,
+            },
         );
 
         Ok(vault_id)
@@ -244,8 +262,19 @@ impl DisciplrVault {
         vault.milestone_validated = true;
         env.storage().instance().set(&vault_key, &vault);
 
-        env.events()
-            .publish((Symbol::new(&env, "milestone_validated"), vault_id), ());
+        // Emitted when the verifier or creator validates a vault milestone.
+        env.events().publish(
+            (
+                Symbol::new(&env, "milestone_validated"),
+                vault_id,
+                vault.creator.clone(),
+            ),
+            VaultLifecycleEventData {
+                amount: vault.amount,
+                destination: None,
+                status: vault.status,
+            },
+        );
         Ok(true)
     }
 
@@ -287,9 +316,18 @@ impl DisciplrVault {
         vault.status = VaultStatus::Completed;
         env.storage().instance().set(&vault_key, &vault);
 
+        // Emitted when vault funds are released to the success destination.
         env.events().publish(
-            (Symbol::new(&env, "funds_released"), vault_id),
-            vault.amount,
+            (
+                Symbol::new(&env, "funds_released"),
+                vault_id,
+                vault.creator.clone(),
+            ),
+            VaultLifecycleEventData {
+                amount: vault.amount,
+                destination: Some(vault.success_destination.clone()),
+                status: vault.status,
+            },
         );
         Ok(true)
     }
@@ -330,9 +368,18 @@ impl DisciplrVault {
         vault.status = VaultStatus::Failed;
         env.storage().instance().set(&vault_key, &vault);
 
+        // Emitted when vault funds are redirected to the failure destination.
         env.events().publish(
-            (Symbol::new(&env, "funds_redirected"), vault_id),
-            vault.amount,
+            (
+                Symbol::new(&env, "funds_redirected"),
+                vault_id,
+                vault.creator.clone(),
+            ),
+            VaultLifecycleEventData {
+                amount: vault.amount,
+                destination: Some(vault.failure_destination.clone()),
+                status: vault.status,
+            },
         );
         Ok(true)
     }
@@ -366,8 +413,19 @@ impl DisciplrVault {
         vault.status = VaultStatus::Cancelled;
         env.storage().instance().set(&vault_key, &vault);
 
-        env.events()
-            .publish((Symbol::new(&env, "vault_cancelled"), vault_id), ());
+        // Emitted when the creator cancels an active vault and receives a refund.
+        env.events().publish(
+            (
+                Symbol::new(&env, "vault_cancelled"),
+                vault_id,
+                vault.creator.clone(),
+            ),
+            VaultLifecycleEventData {
+                amount: vault.amount,
+                destination: Some(vault.creator.clone()),
+                status: vault.status,
+            },
+        );
         Ok(true)
     }
 

--- a/tests/events.rs
+++ b/tests/events.rs
@@ -1,0 +1,172 @@
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::{Address as _, Events, Ledger},
+    token::StellarAssetClient,
+    Address, BytesN, Env, Symbol, TryIntoVal,
+};
+
+use disciplr_vault::{
+    DisciplrVault, DisciplrVaultClient, VaultLifecycleEventData, VaultStatus, MIN_AMOUNT,
+};
+
+struct TestSetup {
+    env: Env,
+    contract_id: Address,
+    client: DisciplrVaultClient<'static>,
+    usdc: Address,
+    creator: Address,
+    verifier: Address,
+    success_dest: Address,
+    failure_dest: Address,
+    milestone: BytesN<32>,
+    now: u64,
+}
+
+impl TestSetup {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(DisciplrVault, ());
+        let client = DisciplrVaultClient::new(&env, &contract_id);
+        let usdc_admin = Address::generate(&env);
+        let usdc_token = env.register_stellar_asset_contract_v2(usdc_admin);
+        let usdc = usdc_token.address();
+        let usdc_asset = StellarAssetClient::new(&env, &usdc);
+
+        let creator = Address::generate(&env);
+        let verifier = Address::generate(&env);
+        let success_dest = Address::generate(&env);
+        let failure_dest = Address::generate(&env);
+        let milestone = BytesN::from_array(&env, &[7u8; 32]);
+        let now = 1_700_000_000u64;
+
+        env.ledger().set_timestamp(now);
+        usdc_asset.mint(&creator, &MIN_AMOUNT);
+
+        Self {
+            env,
+            contract_id,
+            client,
+            usdc,
+            creator,
+            verifier,
+            success_dest,
+            failure_dest,
+            milestone,
+            now,
+        }
+    }
+
+    fn create_vault(&self) -> u32 {
+        self.client.create_vault(
+            &self.usdc,
+            &self.creator,
+            &MIN_AMOUNT,
+            &self.now,
+            &(self.now + 86_400),
+            &self.milestone,
+            &Some(self.verifier.clone()),
+            &self.success_dest,
+            &self.failure_dest,
+        )
+    }
+}
+
+fn assert_lifecycle_event(
+    setup: &TestSetup,
+    event_name: &str,
+    vault_id: u32,
+    expected_destination: Option<Address>,
+    expected_status: VaultStatus,
+) {
+    let expected_name = Symbol::new(&setup.env, event_name);
+    let all_events = setup.env.events().all();
+
+    for (emitting_contract, topics, data) in all_events {
+        if emitting_contract != setup.contract_id {
+            continue;
+        }
+
+        let actual_name: Symbol = topics.get(0).unwrap().try_into_val(&setup.env).unwrap();
+        if actual_name != expected_name {
+            continue;
+        }
+
+        let actual_vault_id: u32 = topics.get(1).unwrap().try_into_val(&setup.env).unwrap();
+        let actual_creator: Address = topics.get(2).unwrap().try_into_val(&setup.env).unwrap();
+        let payload: VaultLifecycleEventData = data.try_into_val(&setup.env).unwrap();
+
+        assert_eq!(actual_vault_id, vault_id);
+        assert_eq!(actual_creator, setup.creator);
+        assert_eq!(payload.amount, MIN_AMOUNT);
+        assert_eq!(payload.destination, expected_destination);
+        assert_eq!(payload.status, expected_status);
+        return;
+    }
+
+    panic!("expected {event_name} lifecycle event for vault {vault_id}");
+}
+
+#[test]
+fn lifecycle_events_use_indexed_topics_and_typed_payloads() {
+    let setup = TestSetup::new();
+
+    let vault_id = setup.create_vault();
+    assert_lifecycle_event(&setup, "vault_created", vault_id, None, VaultStatus::Active);
+
+    setup.env.ledger().set_timestamp(setup.now + 3_600);
+    setup.client.validate_milestone(&vault_id);
+    assert_lifecycle_event(
+        &setup,
+        "milestone_validated",
+        vault_id,
+        None,
+        VaultStatus::Active,
+    );
+
+    setup.client.release_funds(&vault_id, &setup.usdc);
+    assert_lifecycle_event(
+        &setup,
+        "funds_released",
+        vault_id,
+        Some(setup.success_dest.clone()),
+        VaultStatus::Completed,
+    );
+}
+
+#[test]
+fn redirect_event_uses_failure_destination_payload() {
+    let setup = TestSetup::new();
+
+    let vault_id = setup.create_vault();
+    setup.env.ledger().set_timestamp(setup.now + 86_401);
+
+    setup.client.redirect_funds(&vault_id, &setup.usdc);
+
+    assert_lifecycle_event(
+        &setup,
+        "funds_redirected",
+        vault_id,
+        Some(setup.failure_dest.clone()),
+        VaultStatus::Failed,
+    );
+}
+
+#[test]
+fn cancel_event_uses_creator_refund_payload() {
+    let setup = TestSetup::new();
+
+    let vault_id = setup.create_vault();
+
+    setup.client.cancel_vault(&vault_id, &setup.usdc);
+
+    assert_lifecycle_event(
+        &setup,
+        "vault_cancelled",
+        vault_id,
+        Some(setup.creator.clone()),
+        VaultStatus::Cancelled,
+    );
+}

--- a/tests/proptest_timestamps.rs
+++ b/tests/proptest_timestamps.rs
@@ -279,7 +279,6 @@ fn edge_start_eq_now_succeeds() {
     assert_eq!(vault.end_timestamp, end);
 }
 
-
 #[test]
 fn edge_start_eq_end_rejected() {
     let (env, client, usdc, usdc_asset) = setup();


### PR DESCRIPTION
## Summary
- standardize lifecycle event topics to `(event_name, vault_id, creator)` while preserving existing event names
- add a typed `VaultLifecycleEventData { amount, destination, status }` payload for create, validate, release, redirect, and cancel transitions
- add integration tests that assert emitted topics and decoded payloads via `env.events()`
- document the indexer-facing event schema in `docs/EVENTS.md` and update `src/doc.md`

## Tests
- `cargo test --test events -- --nocapture`
- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

Closes #224