### PR TITLE
feat: add partial vault release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ and the machine-readable interface lives in
 | --- | --- | --- |
 | `create_vault` | Yes | Creates and funds a new vault, assigns a sequential vault id, and starts it in `Active`. |
 | `validate_milestone` | Yes | Marks an `Active` vault milestone as validated before the deadline. |
-| `release_funds` | Yes | Sends funds to `success_destination` and moves the vault to `Completed`. |
-| `redirect_funds` | Yes | Sends funds to `failure_destination` and moves the vault to `Failed`. |
-| `cancel_vault` | Yes | Returns funds to the creator and moves the vault to `Cancelled`. |
+| `release_funds` | Yes | Sends the full remaining balance to `success_destination` and moves the vault to `Completed`. |
+| `release_partial` | Yes | Sends a positive tranche to `success_destination` and keeps the vault `Active` until the remaining balance is zero. |
+| `redirect_funds` | Yes | Sends the remaining balance to `failure_destination` and moves the vault to `Failed`. |
+| `cancel_vault` | Yes | Returns the remaining balance to the creator and moves the vault to `Cancelled`. |
 | `get_vault_state` | No | Reads a vault record, returning `None` for an unknown id. |
 | `vault_count` | No | Returns the number of vault ids assigned so far. |
 
@@ -37,20 +38,24 @@ and the backend mapping in [`src/doc.md`](src/doc.md#error-handling).
 | `4` | `InvalidTimestamp` | `create_vault`, `redirect_funds` | `create_vault` receives a `start_timestamp` earlier than the current ledger timestamp, or `redirect_funds` is called at or before `end_timestamp`. The exact deadline case returns `#4`. |
 | `5` | `MilestoneExpired` | `validate_milestone` | The current ledger timestamp is greater than or equal to `end_timestamp`, so validation is no longer allowed. |
 | `6` | `InvalidStatus` | None in the current implementation | Reserved by the enum for invalid-status flows. Current state-changing entrypoints use `VaultNotActive` for non-`Active` vault states. |
-| `7` | `InvalidAmount` | `create_vault` | `amount` is below `MIN_AMOUNT` or above `MAX_AMOUNT`. This covers zero, negative, and over-maximum amounts. |
+| `7` | `InvalidAmount` | `create_vault`, `release_partial` | `create_vault` amount is below `MIN_AMOUNT` or above `MAX_AMOUNT`, or a partial release amount is zero, negative, or greater than the vault's remaining balance. |
 | `8` | `InvalidTimestamps` | `create_vault` | `end_timestamp` is less than or equal to `start_timestamp`. |
 | `9` | `DurationTooLong` | `create_vault` | `end_timestamp - start_timestamp` exceeds `MAX_VAULT_DURATION` (365 days). |
 
 ## Vault Lifecycle
 
 Vault records are never deleted by normal contract operation. A vault starts in
-`Active`; `Completed`, `Failed`, and `Cancelled` are terminal states.
+`Active`; `Completed`, `Failed`, and `Cancelled` are terminal states. Each vault
+stores its original `amount` and a mutable `remaining_amount` so partial success
+releases cannot pay out more than the escrowed balance.
 
 ```mermaid
 stateDiagram-v2
     [*] --> Active: create_vault
     Active --> Active: validate_milestone / milestone_validated = true
+    Active --> Active: release_partial / remaining_amount > 0
     Active --> Completed: release_funds / success_destination receives funds
+    Active --> Completed: release_partial / remaining_amount = 0
     Active --> Failed: redirect_funds / failure_destination receives funds
     Active --> Cancelled: cancel_vault / creator receives refund
     Completed --> [*]
@@ -62,12 +67,16 @@ stateDiagram-v2
 | --- | --- | --- | --- | --- |
 | None | `Active` | `create_vault` | Creator authorizes; amount and timestamps are valid; duration is within the maximum; token transfer into the contract succeeds. | `vault_created` |
 | `Active` | `Active` | `validate_milestone` | Vault exists, is active, caller is the configured verifier or creator fallback, and ledger time is before `end_timestamp`. | `milestone_validated` |
-| `Active` | `Completed` | `release_funds` | Creator authorizes; vault is active; milestone is validated or the deadline has been reached. | `funds_released` |
-| `Active` | `Failed` | `redirect_funds` | Vault is active; ledger time is strictly greater than `end_timestamp`; milestone is not validated. | `funds_redirected` |
-| `Active` | `Cancelled` | `cancel_vault` | Creator authorizes and vault is active. | `vault_cancelled` |
+| `Active` | `Active` | `release_partial` | Creator authorizes; vault is active; milestone is validated or the deadline has been reached; release amount is positive and less than `remaining_amount`. | `funds_released`, `funds_released_partial` |
+| `Active` | `Completed` | `release_funds` / final `release_partial` | Creator authorizes; vault is active; milestone is validated or the deadline has been reached; remaining balance becomes zero. | `funds_released`, `funds_released_partial` for partial API |
+| `Active` | `Failed` | `redirect_funds` | Vault is active; ledger time is strictly greater than `end_timestamp`; milestone is not validated. Only `remaining_amount` is sent. | `funds_redirected` |
+| `Active` | `Cancelled` | `cancel_vault` | Creator authorizes and vault is active. Only `remaining_amount` is refunded. | `vault_cancelled` |
 
 Any attempt to call `validate_milestone`, `release_funds`, `redirect_funds`, or
 `cancel_vault` after a terminal transition returns `VaultNotActive` (`#3`).
+
+See [`docs/PARTIAL_RELEASE.md`](docs/PARTIAL_RELEASE.md) for tranche examples
+and the remaining-balance invariants.
 
 ## Source Of Truth
 

--- a/contract-interface.json
+++ b/contract-interface.json
@@ -17,6 +17,7 @@
       "fields": [
         { "name": "creator", "type": "Address" },
         { "name": "amount", "type": "i128" },
+        { "name": "remaining_amount", "type": "i128" },
         { "name": "start_timestamp", "type": "u64" },
         { "name": "end_timestamp", "type": "u64" },
         { "name": "milestone_hash", "type": "BytesN<32>" },
@@ -74,6 +75,15 @@
       "outputs": { "type": "Result<bool, Error>" }
     },
     {
+      "name": "release_partial",
+      "inputs": [
+        { "name": "vault_id", "type": "u32" },
+        { "name": "usdc_token", "type": "Address" },
+        { "name": "release_amount", "type": "i128" }
+      ],
+      "outputs": { "type": "Result<bool, Error>" }
+    },
+    {
       "name": "redirect_funds",
       "inputs": [
         { "name": "vault_id", "type": "u32" },
@@ -117,6 +127,11 @@
       "name": "funds_released",
       "topic": ["funds_released", "u32"],
       "data": "i128"
+    },
+    {
+      "name": "funds_released_partial",
+      "topic": ["funds_released_partial", "u32"],
+      "data": "(i128, i128)"
     },
     {
       "name": "funds_redirected",

--- a/docs/PARTIAL_RELEASE.md
+++ b/docs/PARTIAL_RELEASE.md
@@ -1,0 +1,35 @@
+# Partial Release
+
+Disciplr vaults support tranche-based success payouts through `release_partial`.
+A vault still records the original escrowed `amount`, and it also tracks
+`remaining_amount` as the source of truth for future payouts, redirects, or
+cancellation refunds.
+
+## Invariants
+
+- `remaining_amount` starts equal to `amount`.
+- Every partial release must be positive and no greater than `remaining_amount`.
+- A partial release transfers only the requested tranche to `success_destination`.
+- The vault stays `Active` while `remaining_amount > 0`.
+- The vault becomes `Completed` when `remaining_amount == 0`.
+- `release_funds` preserves the old full-release behavior by releasing the
+  current `remaining_amount` in one call.
+- `redirect_funds` and `cancel_vault` transfer only `remaining_amount`, so prior
+  success tranches cannot be paid twice.
+
+## Worked Example
+
+A creator funds a vault with `30_000_000` stroops.
+
+1. `remaining_amount = 30_000_000` after creation.
+2. The verifier validates the milestone.
+3. `release_partial(..., 10_000_000)` sends `10_000_000` to
+   `success_destination` and stores `remaining_amount = 20_000_000`.
+4. The vault remains `Active`.
+5. A final `release_funds(...)` sends the remaining `20_000_000` and marks the
+   vault `Completed`.
+
+Deadline-based releases use the same authorization gate as `release_funds`. If
+a creator releases a partial tranche after the deadline without milestone
+validation, the unreleased remainder can still be redirected to
+`failure_destination` because the milestone remains unvalidated.

--- a/src/doc.md
+++ b/src/doc.md
@@ -26,6 +26,7 @@ This guide provides comprehensive documentation for backend developers integrati
 | `create_vault` | POST | `/api/v1/vaults` | Create new productivity vault |
 | `validate_milestone` | POST | `/api/v1/vaults/{vault_id}/validate` | Validate milestone completion |
 | `release_funds` | POST | `/api/v1/vaults/{vault_id}/release` | Release funds to success destination |
+| `release_partial` | POST | `/api/v1/vaults/{vault_id}/release-partial` | Release a success tranche and keep tracking remaining escrow |
 | `redirect_funds` | POST | `/api/v1/vaults/{vault_id}/redirect` | Redirect funds to failure destination |
 | `cancel_vault` | POST | `/api/v1/vaults/{vault_id}/cancel` | Cancel vault and return funds |
 | `get_vault_state` | GET | `/api/v1/vaults/{vault_id}` | Query vault state |
@@ -176,6 +177,7 @@ This guide provides comprehensive documentation for backend developers integrati
   "vault_id": 42,
   "status": "Completed",
   "amount_released": "1000000000",
+  "remaining_amount": "0",
   "destination": "GC7XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
   "transaction_hash": "b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3",
   "ledger_sequence": 12345682,
@@ -190,6 +192,39 @@ This guide provides comprehensive documentation for backend developers integrati
 | 404 | `VaultNotFound` | Vault does not exist |
 | 400 | `VaultNotActive` | Vault is not in Active status |
 | 401 | `NotAuthorized` | Release conditions not met (not validated and before deadline) |
+
+---
+
+### 3a. Release Partial Funds
+
+**Endpoint:** `POST /api/v1/vaults/{vault_id}/release-partial`
+
+**Request Payload:**
+```json
+{
+  "vault_id": 42,
+  "usdc_token": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+  "release_amount": "250000000",
+  "caller_signature": "signature_data_here"
+}
+```
+
+Partial release uses the same validation-or-deadline gate as `release_funds`.
+`release_amount` must be positive and no greater than `remaining_amount`.
+
+**Response (200 OK):**
+```json
+{
+  "vault_id": 42,
+  "status": "Active",
+  "amount_released": "250000000",
+  "remaining_amount": "750000000",
+  "destination": "GC7XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "transaction_hash": "b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3",
+  "ledger_sequence": 12345682,
+  "released_at": "2024-01-20T00:00:00Z"
+}
+```
 
 ---
 
@@ -303,6 +338,7 @@ This guide provides comprehensive documentation for backend developers integrati
   "vault": {
     "creator": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
     "amount": "1000000000",
+    "remaining_amount": "1000000000",
     "start_timestamp": 1704067200,
     "end_timestamp": 1706640000,
     "milestone_hash": "4d696c6573746f6e655f726571756972656d656e74735f68617368",
@@ -495,7 +531,8 @@ class ReleaseService {
     return {
       vault_id: request.vault_id,
       status: 'Completed',
-      amount_released: vault.amount,
+      amount_released: vault.remaining_amount,
+      remaining_amount: '0',
       destination: vault.success_destination,
       transaction_hash: result.txHash,
       ledger_sequence: result.ledger,
@@ -616,6 +653,7 @@ class EventMonitor {
         ['vault_created', vaultId.toString()],
         ['milestone_validated', vaultId.toString()],
         ['funds_released', vaultId.toString()],
+        ['funds_released_partial', vaultId.toString()],
         ['funds_redirected', vaultId.toString()],
         ['vault_cancelled', vaultId.toString()]
       ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,8 @@ pub struct ProductivityVault {
     pub creator: Address,
     /// USDC amount locked in the vault (in stroops / smallest unit).
     pub amount: i128,
+    /// Escrow still available for future success release, redirect, or cancel.
+    pub remaining_amount: i128,
     /// Ledger timestamp when the commitment period starts.
     pub start_timestamp: u64,
     /// Ledger timestamp after which deadline-based release is allowed.
@@ -113,6 +115,66 @@ pub const MAX_AMOUNT: i128 = 10_000_000_000_000; // 10M USDC
 pub enum DataKey {
     Vault(u32),
     VaultCount,
+}
+
+fn release_vault_amount(
+    env: Env,
+    vault_id: u32,
+    usdc_token: Address,
+    release_amount: i128,
+    emit_partial_event: bool,
+) -> Result<bool, Error> {
+    let vault_key = DataKey::Vault(vault_id);
+    let mut vault: ProductivityVault = env
+        .storage()
+        .instance()
+        .get(&vault_key)
+        .ok_or(Error::VaultNotFound)?;
+
+    vault.creator.require_auth();
+
+    if vault.status != VaultStatus::Active {
+        return Err(Error::VaultNotActive);
+    }
+
+    let now = env.ledger().timestamp();
+    let deadline_reached = now >= vault.end_timestamp;
+    let validated = vault.milestone_validated;
+
+    if !validated && !deadline_reached {
+        return Err(Error::NotAuthorized);
+    }
+    if release_amount <= 0 || release_amount > vault.remaining_amount {
+        return Err(Error::InvalidAmount);
+    }
+
+    let token_client = token::Client::new(&env, &usdc_token);
+    token_client.transfer(
+        &env.current_contract_address(),
+        &vault.success_destination,
+        &release_amount,
+    );
+
+    vault.remaining_amount = vault
+        .remaining_amount
+        .checked_sub(release_amount)
+        .ok_or(Error::InvalidAmount)?;
+    if vault.remaining_amount == 0 {
+        vault.status = VaultStatus::Completed;
+    }
+    env.storage().instance().set(&vault_key, &vault);
+
+    env.events().publish(
+        (Symbol::new(&env, "funds_released"), vault_id),
+        release_amount,
+    );
+    if emit_partial_event {
+        env.events().publish(
+            (Symbol::new(&env, "funds_released_partial"), vault_id),
+            (release_amount, vault.remaining_amount),
+        );
+    }
+    Ok(true)
 }
 
 // ---------------------------------------------------------------------------
@@ -186,6 +248,7 @@ impl DisciplrVault {
         let vault = ProductivityVault {
             creator,
             amount,
+            remaining_amount: amount,
             start_timestamp,
             end_timestamp,
             milestone_hash,
@@ -253,45 +316,29 @@ impl DisciplrVault {
     // release_funds
     // -----------------------------------------------------------------------
 
-    /// Release vault funds to `success_destination`.
+    /// Release the full remaining vault balance to `success_destination`.
     pub fn release_funds(env: Env, vault_id: u32, usdc_token: Address) -> Result<bool, Error> {
         let vault_key = DataKey::Vault(vault_id);
-        let mut vault: ProductivityVault = env
+        let vault: ProductivityVault = env
             .storage()
             .instance()
             .get(&vault_key)
             .ok_or(Error::VaultNotFound)?;
 
-        vault.creator.require_auth();
+        release_vault_amount(env, vault_id, usdc_token, vault.remaining_amount, false)
+    }
 
-        if vault.status != VaultStatus::Active {
-            return Err(Error::VaultNotActive); // Or InvalidStatus as appropriate
-        }
-
-        // Check release conditions.
-        let now = env.ledger().timestamp();
-        let deadline_reached = now >= vault.end_timestamp;
-        let validated = vault.milestone_validated;
-
-        if !validated && !deadline_reached {
-            return Err(Error::NotAuthorized);
-        }
-
-        let token_client = token::Client::new(&env, &usdc_token);
-        token_client.transfer(
-            &env.current_contract_address(),
-            &vault.success_destination,
-            &vault.amount,
-        );
-
-        vault.status = VaultStatus::Completed;
-        env.storage().instance().set(&vault_key, &vault);
-
-        env.events().publish(
-            (Symbol::new(&env, "funds_released"), vault_id),
-            vault.amount,
-        );
-        Ok(true)
+    /// Release a positive tranche to `success_destination`.
+    ///
+    /// The vault remains `Active` while `remaining_amount` is non-zero and moves
+    /// to `Completed` only when the escrow has been fully released.
+    pub fn release_partial(
+        env: Env,
+        vault_id: u32,
+        usdc_token: Address,
+        release_amount: i128,
+    ) -> Result<bool, Error> {
+        release_vault_amount(env, vault_id, usdc_token, release_amount, true)
     }
 
     // -----------------------------------------------------------------------
@@ -324,15 +371,17 @@ impl DisciplrVault {
         token_client.transfer(
             &env.current_contract_address(),
             &vault.failure_destination,
-            &vault.amount,
+            &vault.remaining_amount,
         );
 
+        let redirected_amount = vault.remaining_amount;
+        vault.remaining_amount = 0;
         vault.status = VaultStatus::Failed;
         env.storage().instance().set(&vault_key, &vault);
 
         env.events().publish(
             (Symbol::new(&env, "funds_redirected"), vault_id),
-            vault.amount,
+            redirected_amount,
         );
         Ok(true)
     }
@@ -360,9 +409,10 @@ impl DisciplrVault {
         token_client.transfer(
             &env.current_contract_address(),
             &vault.creator,
-            &vault.amount,
+            &vault.remaining_amount,
         );
 
+        vault.remaining_amount = 0;
         vault.status = VaultStatus::Cancelled;
         env.storage().instance().set(&vault_key, &vault);
 
@@ -529,6 +579,7 @@ mod tests {
         let vault = vault_state.unwrap();
         assert_eq!(vault.creator, setup.creator);
         assert_eq!(vault.amount, setup.amount);
+        assert_eq!(vault.remaining_amount, setup.amount);
         assert_eq!(vault.start_timestamp, setup.start_timestamp);
         assert_eq!(vault.end_timestamp, setup.end_timestamp);
         assert_eq!(vault.milestone_hash, setup.milestone_hash());
@@ -559,6 +610,7 @@ mod tests {
 
         let vault = client.get_vault_state(&vault_id).unwrap();
         assert_eq!(vault.status, VaultStatus::Cancelled);
+        assert_eq!(vault.remaining_amount, 0);
     }
 
     #[test]
@@ -575,6 +627,7 @@ mod tests {
 
         let vault = client.get_vault_state(&vault_id).unwrap();
         assert_eq!(vault.status, VaultStatus::Failed);
+        assert_eq!(vault.remaining_amount, 0);
     }
 
     /// Issue #42: milestone_hash passed to create_vault is stored and returned by get_vault_state.

--- a/test_snapshots/test/test_create_vault_exact_balance.1.json
+++ b/test_snapshots/test/test_create_vault_exact_balance.1.json
@@ -346,6 +346,17 @@
                             },
                             {
                               "key": {
+                                "symbol": "remaining_amount"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 10000000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "start_timestamp"
                               },
                               "val": {

--- a/test_snapshots/test/test_create_vault_success.1.json
+++ b/test_snapshots/test/test_create_vault_success.1.json
@@ -346,6 +346,17 @@
                             },
                             {
                               "key": {
+                                "symbol": "remaining_amount"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 10000000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "start_timestamp"
                               },
                               "val": {

--- a/test_snapshots/test/test_create_vault_with_verifier.1.json
+++ b/test_snapshots/test/test_create_vault_with_verifier.1.json
@@ -347,6 +347,17 @@
                             },
                             {
                               "key": {
+                                "symbol": "remaining_amount"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 10000000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "start_timestamp"
                               },
                               "val": {

--- a/test_snapshots/tests/test_get_vault_state_cancelled_vault_still_returns_some.1.json
+++ b/test_snapshots/tests/test_get_vault_state_cancelled_vault_still_returns_some.1.json
@@ -402,6 +402,17 @@
                             },
                             {
                               "key": {
+                                "symbol": "remaining_amount"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "start_timestamp"
                               },
                               "val": {

--- a/test_snapshots/tests/test_get_vault_state_failed_vault_still_returns_some.1.json
+++ b/test_snapshots/tests/test_get_vault_state_failed_vault_still_returns_some.1.json
@@ -348,6 +348,17 @@
                             },
                             {
                               "key": {
+                                "symbol": "remaining_amount"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 0
+                                }
+                              }
+                            },
+                            {
+                              "key": {
                                 "symbol": "start_timestamp"
                               },
                               "val": {

--- a/tests/partial_release.rs
+++ b/tests/partial_release.rs
@@ -1,0 +1,226 @@
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token::{StellarAssetClient, TokenClient},
+    Address, BytesN, Env,
+};
+
+use disciplr_vault::{DisciplrVault, DisciplrVaultClient, VaultStatus, MIN_AMOUNT};
+
+struct Setup {
+    env: Env,
+    client: DisciplrVaultClient<'static>,
+    usdc: Address,
+    token: TokenClient<'static>,
+    asset: StellarAssetClient<'static>,
+    creator: Address,
+    verifier: Address,
+    success: Address,
+    failure: Address,
+    now: u64,
+}
+
+impl Setup {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+        let now = 1_700_100_000u64;
+        env.ledger().set_timestamp(now);
+
+        let contract_id = env.register(DisciplrVault, ());
+        let client = DisciplrVaultClient::new(&env, &contract_id);
+
+        let usdc_admin = Address::generate(&env);
+        let usdc_contract = env.register_stellar_asset_contract_v2(usdc_admin);
+        let usdc = usdc_contract.address();
+        let asset = StellarAssetClient::new(&env, &usdc);
+        let token = TokenClient::new(&env, &usdc);
+
+        let creator = Address::generate(&env);
+        let verifier = Address::generate(&env);
+        let success = Address::generate(&env);
+        let failure = Address::generate(&env);
+
+        Self {
+            env,
+            client,
+            usdc,
+            token,
+            asset,
+            creator,
+            verifier,
+            success,
+            failure,
+            now,
+        }
+    }
+
+    fn create_vault(&self, amount: i128) -> u32 {
+        self.asset.mint(&self.creator, &amount);
+        self.client.create_vault(
+            &self.usdc,
+            &self.creator,
+            &amount,
+            &self.now,
+            &(self.now + 86_400),
+            &BytesN::from_array(&self.env, &[21u8; 32]),
+            &Some(self.verifier.clone()),
+            &self.success,
+            &self.failure,
+        )
+    }
+}
+
+#[test]
+fn partial_release_keeps_vault_active_and_tracks_remaining_balance() {
+    let setup = Setup::new();
+    let amount = MIN_AMOUNT * 3;
+    let vault_id = setup.create_vault(amount);
+
+    setup.env.ledger().set_timestamp(setup.now + 3_600);
+    setup.client.validate_milestone(&vault_id);
+
+    let first_tranche = MIN_AMOUNT;
+    setup
+        .client
+        .release_partial(&vault_id, &setup.usdc, &first_tranche);
+
+    let vault = setup.client.get_vault_state(&vault_id).unwrap();
+    assert_eq!(vault.status, VaultStatus::Active);
+    assert_eq!(vault.amount, amount);
+    assert_eq!(vault.remaining_amount, amount - first_tranche);
+    assert_eq!(setup.token.balance(&setup.success), first_tranche);
+}
+
+#[test]
+fn final_partial_release_completes_vault() {
+    let setup = Setup::new();
+    let amount = MIN_AMOUNT * 2;
+    let vault_id = setup.create_vault(amount);
+
+    setup.env.ledger().set_timestamp(setup.now + 3_600);
+    setup.client.validate_milestone(&vault_id);
+
+    setup
+        .client
+        .release_partial(&vault_id, &setup.usdc, &MIN_AMOUNT);
+    setup
+        .client
+        .release_partial(&vault_id, &setup.usdc, &MIN_AMOUNT);
+
+    let vault = setup.client.get_vault_state(&vault_id).unwrap();
+    assert_eq!(vault.status, VaultStatus::Completed);
+    assert_eq!(vault.remaining_amount, 0);
+    assert_eq!(setup.token.balance(&setup.success), amount);
+}
+
+#[test]
+fn release_funds_drains_remaining_after_partial_release() {
+    let setup = Setup::new();
+    let amount = MIN_AMOUNT * 4;
+    let vault_id = setup.create_vault(amount);
+
+    setup.env.ledger().set_timestamp(setup.now + 3_600);
+    setup.client.validate_milestone(&vault_id);
+
+    let first_tranche = MIN_AMOUNT;
+    setup
+        .client
+        .release_partial(&vault_id, &setup.usdc, &first_tranche);
+    setup.client.release_funds(&vault_id, &setup.usdc);
+
+    let vault = setup.client.get_vault_state(&vault_id).unwrap();
+    assert_eq!(vault.status, VaultStatus::Completed);
+    assert_eq!(vault.remaining_amount, 0);
+    assert_eq!(setup.token.balance(&setup.success), amount);
+}
+
+#[test]
+fn invalid_partial_amounts_are_rejected() {
+    let setup = Setup::new();
+    let amount = MIN_AMOUNT * 2;
+    let vault_id = setup.create_vault(amount);
+
+    setup.env.ledger().set_timestamp(setup.now + 3_600);
+    setup.client.validate_milestone(&vault_id);
+
+    assert!(setup
+        .client
+        .try_release_partial(&vault_id, &setup.usdc, &0)
+        .is_err());
+    assert!(setup
+        .client
+        .try_release_partial(&vault_id, &setup.usdc, &(amount + 1))
+        .is_err());
+}
+
+#[test]
+fn partial_release_requires_same_authorization_gate_as_full_release() {
+    let setup = Setup::new();
+    let vault_id = setup.create_vault(MIN_AMOUNT * 2);
+
+    assert!(setup
+        .client
+        .try_release_partial(&vault_id, &setup.usdc, &MIN_AMOUNT)
+        .is_err());
+}
+
+#[test]
+fn redirect_after_validated_partial_release_is_rejected() {
+    let setup = Setup::new();
+    let amount = MIN_AMOUNT * 3;
+    let vault_id = setup.create_vault(amount);
+
+    setup.env.ledger().set_timestamp(setup.now + 3_600);
+    setup.client.validate_milestone(&vault_id);
+    setup
+        .client
+        .release_partial(&vault_id, &setup.usdc, &MIN_AMOUNT);
+
+    let result = setup.client.try_redirect_funds(&vault_id, &setup.usdc);
+    assert!(result.is_err());
+}
+
+#[test]
+fn redirect_after_deadline_partial_release_sends_only_remaining_balance() {
+    let setup = Setup::new();
+    let amount = MIN_AMOUNT * 3;
+    let vault_id = setup.create_vault(amount);
+
+    setup.env.ledger().set_timestamp(setup.now + 86_401);
+    setup
+        .client
+        .release_partial(&vault_id, &setup.usdc, &MIN_AMOUNT);
+    setup.client.redirect_funds(&vault_id, &setup.usdc);
+
+    let vault = setup.client.get_vault_state(&vault_id).unwrap();
+    assert_eq!(vault.status, VaultStatus::Failed);
+    assert_eq!(vault.remaining_amount, 0);
+    assert_eq!(setup.token.balance(&setup.success), MIN_AMOUNT);
+    assert_eq!(setup.token.balance(&setup.failure), amount - MIN_AMOUNT);
+}
+
+#[test]
+fn cancel_after_partial_release_refunds_only_remaining_balance() {
+    let setup = Setup::new();
+    let amount = MIN_AMOUNT * 3;
+    let vault_id = setup.create_vault(amount);
+
+    setup.env.ledger().set_timestamp(setup.now + 3_600);
+    setup.client.validate_milestone(&vault_id);
+    setup
+        .client
+        .release_partial(&vault_id, &setup.usdc, &MIN_AMOUNT);
+
+    let creator_before = setup.token.balance(&setup.creator);
+    setup.client.cancel_vault(&vault_id, &setup.usdc);
+
+    let vault = setup.client.get_vault_state(&vault_id).unwrap();
+    assert_eq!(vault.status, VaultStatus::Cancelled);
+    assert_eq!(vault.remaining_amount, 0);
+    assert_eq!(
+        setup.token.balance(&setup.creator) - creator_before,
+        amount - MIN_AMOUNT
+    );
+}

--- a/tests/proptest_timestamps.rs
+++ b/tests/proptest_timestamps.rs
@@ -279,7 +279,6 @@ fn edge_start_eq_now_succeeds() {
     assert_eq!(vault.end_timestamp, end);
 }
 
-
 #[test]
 fn edge_start_eq_end_rejected() {
     let (env, client, usdc, usdc_asset) = setup();


### PR DESCRIPTION
## Summary
- add `remaining_amount` tracking to vault state for tranche-based settlement
- add `release_partial` while preserving `release_funds` as a full remaining-balance release
- make redirect/cancel transfer only unreleased escrow after partial success payouts
- document partial release semantics and update the interface mapping

## Tests
- `cargo fmt --check`
- `cargo test --test partial_release -- --nocapture`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

Closes #218