### PR TITLE
Add CODEOWNERS review routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Review routing for Disciplr Vault changes.
+#
+# Replace @1nonlypiece with an org team such as
+# @Disciplr-Org/maintainers if/when that team is available publicly.
+
+* @1nonlypiece
+
+/src/ @1nonlypiece
+/tests/ @1nonlypiece
+/docs/ @1nonlypiece
+/.github/workflows/ @1nonlypiece
+/contract-interface.json @1nonlypiece
+/Cargo.toml @1nonlypiece
+/Cargo.lock @1nonlypiece
+


### PR DESCRIPTION
## Summary

Fixes #271.

Adds `.github/CODEOWNERS` so changes to contract source, tests, documentation, workflows, and key contract metadata files route to a reviewer automatically.

## Notes

GitHub's public API did not expose any `Disciplr-Org` team slugs to this contributor account, so this initial file routes reviews to `@1nonlypiece`, the repository's top contributor. If the project has a private maintainer team, this can be swapped to that team slug, for example `@Disciplr-Org/maintainers`.

## Verification

- Ran `git diff --check`
- Configuration-only change; Cargo tests were not run

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the repository metadata and final diff before submitting.