### PR TITLE
Fix create_vault USDC token docs

### DIFF
--- a/vesting.md
+++ b/vesting.md
@@ -78,6 +78,7 @@ Creates a new productivity vault and locks USDC funds.
 ```rust
 pub fn create_vault(
     env: Env,
+    usdc_token: Address,
     creator: Address,
     amount: i128,
     start_timestamp: u64,
@@ -86,10 +87,11 @@ pub fn create_vault(
     verifier: Option<Address>,
     success_destination: Address,
     failure_destination: Address,
-) -> u32
+) -> Result<u32, Error>
 ```
 
 **Parameters:**
+- `usdc_token`: Address of the USDC token contract to transfer from and later release or redirect
 - `creator`: Address of the vault creator (must authorize transaction)
 - `amount`: USDC amount to lock (in stroops)
 - `start_timestamp`: When vault becomes active (unix seconds)
@@ -366,10 +368,12 @@ let milestone_hash: BytesN<32> = BytesN::from_array(&env, &[
 let verifier: Option<Address> = Some(Address::from_string("GB7..."));
 let success_destination: Address = Address::from_string("GC7..."); // Project wallet
 let failure_destination: Address = Address::from_string("GD7..."); // Funder wallet
+let usdc_token: Address = Address::from_string("GE7..."); // USDC token contract
 
 // Create vault
 let vault_id = DisciplrVaultClient::new(&env, &contract_address)
     .create_vault(
+        &usdc_token,
         &creator,
         &amount,
         &start_timestamp,


### PR DESCRIPTION
## Summary

Fixes #357.

Updates `vesting.md` so the documented `create_vault` signature and usage example include the `usdc_token` address as the first contract argument, matching the real `src/lib.rs` implementation.

## Changes

- Add `usdc_token: Address` to the documented `create_vault` signature
- Document the `usdc_token` parameter
- Add `&usdc_token` to Example 1's client call
- Align the documented return type with `Result<u32, Error>`

## Verification

- Ran `git diff --check`
- Documentation-only change; Cargo tests were not run

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the issue, real `src/lib.rs` signature, and final diff before submitting.