### PR TITLE
Document read-only authorization entries

### DIFF
--- a/src/doc.md
+++ b/src/doc.md
@@ -591,6 +591,8 @@ All transactions benefit from Stellar's built-in replay protection via sequence 
 | `release_funds` | Anyone | Conditions: validated OR past deadline |
 | `redirect_funds` | Anyone | Conditions: not validated AND past deadline |
 | `cancel_vault` | Creator only | Vault must be Active |
+| `get_vault_state` | Anyone | Read-only; no authorization required |
+| `vault_count` | Anyone | Read-only; no authorization required |
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #344.

Completes the `src/doc.md` Authorization Matrix by adding the two read-only entrypoints that do not require authorization.

## Changes

- Add `get_vault_state` to the authorization matrix as a public read-only operation
- Add `vault_count` to the authorization matrix as a public read-only operation

## Verification

- Ran `git diff --check`
- Documentation-only change; Cargo tests were not run

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the issue, real `src/lib.rs` entrypoints, and final diff before submitting.