### PR TITLE
Link supporting reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,11 @@ Any attempt to call `validate_milestone`, `release_funds`, `redirect_funds`, or
   for integrators and tooling.
 - [`src/doc.md`](src/doc.md) maps these contract semantics to backend API
   payloads and HTTP error responses.
+- [`vesting.md`](vesting.md) documents the broader vault trust model, lifecycle,
+  and security considerations.
+- [`USDC_INTEGRATION.md`](USDC_INTEGRATION.md) explains token integration
+  assumptions and USDC transfer behavior.
+- [`TESTING_GUIDE.md`](TESTING_GUIDE.md) describes how to run, extend, and
+  maintain the test suite.
+- [`CHANGELOG.md`](CHANGELOG.md) records release history and notable contract
+  changes.


### PR DESCRIPTION
## Summary

Fixes #353.

Expands README.md's Source Of Truth section so readers can discover the repository's supporting contract documentation from the main entry point.

## Changes

- Link `vesting.md` for trust model, lifecycle, and security notes
- Link `USDC_INTEGRATION.md` for token integration assumptions
- Link `TESTING_GUIDE.md` for test workflow guidance
- Link `CHANGELOG.md` for release history

## Verification

- Ran `git diff --check`
- Documentation-only change; Cargo tests were not run

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the issue, existing documentation files, and final diff before submitting.