### PR TITLE
Refresh vesting file structure docs

### DIFF
--- a/vesting.md
+++ b/vesting.md
@@ -477,13 +477,40 @@ Expected output should include tests for:
 
 ```
 disciplr-contracts/
-├── src/
-│   └── lib.rs           # DisciplrVault contract implementation
-├── tests/
-│   └── create_vault.rs  # Integration tests for create_vault
-├── Cargo.toml           # Project dependencies
-├── README.md            # Project overview
-└── vesting.md           # This documentation
+|-- .cargo/
+|   `-- audit.toml
+|-- .github/
+|   `-- workflows/
+|       |-- ci.yml
+|       `-- coverage.yml
+|-- docs/
+|   `-- MERGE_HYGIENE.md
+|-- src/
+|   |-- doc.md
+|   `-- lib.rs
+|-- tests/
+|   |-- create_vault.rs
+|   |-- lifecycle.rs
+|   |-- proptest_amounts.rs
+|   `-- proptest_timestamps.rs
+|-- test_snapshots/
+|   `-- ... generated test snapshots
+|-- Cargo.toml
+|-- Cargo.lock
+|-- contract-interface.json
+|-- README.md
+|-- vesting.md
+|-- USDC_INTEGRATION.md
+|-- TESTING_GUIDE.md
+|-- CHANGELOG.md
+|-- COVERAGE_ANALYSIS.md
+|-- COVERAGE_REPORT.md
+|-- TEST_SUMMARY.md
+|-- TEST_VERIFIER_SAME_AS_CREATOR.md
+|-- README_CANCEL_VAULT.md
+|-- Documentation_validate_milestone_wrong_status.md
+|-- rustfmt.toml
+`-- tarpaulin.toml
 ```
 
 ---


### PR DESCRIPTION
## Summary

Fixes #356.

Refreshes `vesting.md`'s File Structure section so it reflects the repository's current source, tests, docs, workflow, and configuration files instead of the older five-entry layout.

## Changes

- Replace the stale file tree with an updated ASCII tree
- Include current source and test files
- Include supporting docs, workflows, snapshots, and tooling configuration

## Verification

- Ran `git diff --check`
- Documentation-only change; Cargo tests were not run

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the issue, current repository file listing, and final diff before submitting.