### PR TITLE
Consolidate merge hygiene guidance

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -2,10 +2,10 @@
 
 ## Quick Start
 
-```bash
-# Check for unresolved merge conflict markers
-git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- .
+Before pushing a branch, check [Merge Hygiene](./docs/MERGE_HYGIENE.md) for the
+local unresolved-conflict-marker guard that CI also enforces.
 
+```bash
 # Run all tests
 cargo test
 
@@ -119,10 +119,9 @@ cargo tarpaulin --out Html --out Xml --out Lcov --output-dir coverage
 .github/workflows/coverage.yml
 ```
 
-The main CI workflow also runs a merge-conflict marker guard before formatting,
-build, and tests. The guard fails if any file contains a line starting with
-`<<<<<<<`, `=======`, or `>>>>>>>`. See [docs/MERGE_HYGIENE.md](./docs/MERGE_HYGIENE.md)
-for the local check and resolution steps.
+The main CI workflow also runs the merge-conflict marker guard before formatting,
+build, and tests. See [docs/MERGE_HYGIENE.md](./docs/MERGE_HYGIENE.md) for the
+single source of truth for the local check and resolution steps.
 
 ## Understanding Coverage Metrics
 


### PR DESCRIPTION
## Summary

Fixes #352.

Consolidates merge-conflict-marker guidance into `docs/MERGE_HYGIENE.md` and keeps `TESTING_GUIDE.md` as a pointer to that single source of truth.

## Changes

- Remove the duplicated `git grep` command from `TESTING_GUIDE.md` Quick Start
- Replace repeated CI guard details with a concise link to `docs/MERGE_HYGIENE.md`

## Verification

- Ran `git diff --check`
- Verified `TESTING_GUIDE.md` no longer repeats the conflict-marker grep command or marker literals

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the issue, duplicate guidance, and final diff before submitting.