### PR TITLE
Test funds redirected event

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -933,6 +933,45 @@ mod tests {
     }
 
     #[test]
+    fn test_redirect_funds_emits_event_with_amount() {
+        let setup = TestSetup::new();
+        let client = setup.client();
+
+        setup.env.ledger().set_timestamp(setup.start_timestamp);
+        let vault_id = setup.create_default_vault();
+        setup.env.ledger().set_timestamp(setup.end_timestamp + 1);
+
+        client.redirect_funds(&vault_id, &setup.usdc_token);
+
+        let all_events = setup.env.events().all();
+        let mut found_funds_redirected = false;
+        for (emitting_contract, topics, data) in all_events {
+            if emitting_contract == setup.contract_id {
+                let event_name: Symbol = topics
+                    .get(0)
+                    .unwrap()
+                    .try_into_val(&setup.env)
+                    .unwrap();
+                if event_name == Symbol::new(&setup.env, "funds_redirected") {
+                    let event_vault_id: u32 = topics
+                        .get(1)
+                        .unwrap()
+                        .try_into_val(&setup.env)
+                        .unwrap();
+                    let event_amount: i128 = data.try_into_val(&setup.env).unwrap();
+                    assert_eq!(event_vault_id, vault_id);
+                    assert_eq!(event_amount, setup.amount);
+                    found_funds_redirected = true;
+                }
+            }
+        }
+        assert!(
+            found_funds_redirected,
+            "funds_redirected event must be emitted"
+        );
+    }
+
+    #[test]
     fn test_redirect_funds_before_deadline_rejected() {
         let setup = TestSetup::new();
         let client = setup.client();


### PR DESCRIPTION
## Summary

Fixes #337.

Adds a regression test proving `redirect_funds` emits the documented `funds_redirected` event with the expected topic, vault id, and amount payload.

## Changes

- Add `test_redirect_funds_emits_event_with_amount`
- Assert the emitted event name is `funds_redirected`
- Assert the event topic contains the redirected vault id
- Assert the event data equals the vault amount

## Verification

- Ran `git diff --check`
- Could not run Cargo locally because `cargo` is not installed in this environment

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the issue, existing event test pattern, redirect payload behavior, and final diff before submitting.