### PR TITLE
Test vault cancelled event

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -982,6 +982,42 @@ mod tests {
         assert_eq!(vault.status, VaultStatus::Cancelled);
     }
 
+    #[test]
+    fn test_cancel_vault_emits_event() {
+        let setup = TestSetup::new();
+        let client = setup.client();
+
+        setup.env.ledger().set_timestamp(setup.start_timestamp);
+        let vault_id = setup.create_default_vault();
+
+        client.cancel_vault(&vault_id, &setup.usdc_token);
+
+        let all_events = setup.env.events().all();
+        let mut found_vault_cancelled = false;
+        for (emitting_contract, topics, _) in all_events {
+            if emitting_contract == setup.contract_id {
+                let event_name: Symbol = topics
+                    .get(0)
+                    .unwrap()
+                    .try_into_val(&setup.env)
+                    .unwrap();
+                if event_name == Symbol::new(&setup.env, "vault_cancelled") {
+                    let event_vault_id: u32 = topics
+                        .get(1)
+                        .unwrap()
+                        .try_into_val(&setup.env)
+                        .unwrap();
+                    assert_eq!(event_vault_id, vault_id);
+                    found_vault_cancelled = true;
+                }
+            }
+        }
+        assert!(
+            found_vault_cancelled,
+            "vault_cancelled event must be emitted"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // More upstream tests migrated
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #338.

Adds a regression test proving `cancel_vault` emits the documented `vault_cancelled` event with the expected topic and vault id.

## Changes

- Add `test_cancel_vault_emits_event`
- Assert the emitted event name is `vault_cancelled`
- Assert the event topic contains the cancelled vault id

## Verification

- Ran `git diff --check`
- Could not run Cargo locally because `cargo` is not installed in this environment

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the issue, existing event test pattern, cancel event behavior, and final diff before submitting.