### PR TITLE
Test vault status discriminants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -517,6 +517,14 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
+    fn test_vault_status_discriminants_are_stable() {
+        assert_eq!(VaultStatus::Active as u32, 0);
+        assert_eq!(VaultStatus::Completed as u32, 1);
+        assert_eq!(VaultStatus::Failed as u32, 2);
+        assert_eq!(VaultStatus::Cancelled as u32, 3);
+    }
+
+    #[test]
     fn get_vault_state_returns_some_with_matching_fields() {
         let setup = TestSetup::new();
         let client = setup.client();


### PR DESCRIPTION
## Summary

Fixes #333.

Adds a small regression test pinning the public numeric discriminants for `VaultStatus`.

## Changes

- Assert `Active == 0`
- Assert `Completed == 1`
- Assert `Failed == 2`
- Assert `Cancelled == 3`

## Verification

- Ran `git diff --check`
- Could not run Cargo locally because `cargo` is not installed in this environment

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the issue, enum definition, and final diff before submitting.