### PR TITLE
Test error discriminants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -517,6 +517,19 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
+    fn test_error_discriminants_are_stable() {
+        assert_eq!(Error::VaultNotFound as u32, 1);
+        assert_eq!(Error::NotAuthorized as u32, 2);
+        assert_eq!(Error::VaultNotActive as u32, 3);
+        assert_eq!(Error::InvalidTimestamp as u32, 4);
+        assert_eq!(Error::MilestoneExpired as u32, 5);
+        assert_eq!(Error::InvalidStatus as u32, 6);
+        assert_eq!(Error::InvalidAmount as u32, 7);
+        assert_eq!(Error::InvalidTimestamps as u32, 8);
+        assert_eq!(Error::DurationTooLong as u32, 9);
+    }
+
+    #[test]
     fn get_vault_state_returns_some_with_matching_fields() {
         let setup = TestSetup::new();
         let client = setup.client();


### PR DESCRIPTION
## Summary

Fixes #334.

Adds a small regression test pinning the public numeric discriminants for the contract `Error` enum.

## Changes

- Assert `VaultNotFound == 1`
- Assert `NotAuthorized == 2`
- Assert `VaultNotActive == 3`
- Assert `InvalidTimestamp == 4`
- Assert `MilestoneExpired == 5`
- Assert `InvalidStatus == 6`
- Assert `InvalidAmount == 7`
- Assert `InvalidTimestamps == 8`
- Assert `DurationTooLong == 9`

## Verification

- Ran `git diff --check`
- Could not run Cargo locally because `cargo` is not installed in this environment

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the issue, enum definition, documented error-code mapping, and final diff before submitting.