### PR TITLE
Test vault count

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -801,6 +801,24 @@ mod tests {
     }
 
     #[test]
+    fn test_vault_count_tracks_created_vaults() {
+        let setup = TestSetup::new();
+        let client = setup.client();
+
+        assert_eq!(client.vault_count(), 0);
+
+        // Mint extra USDC for the second vault.
+        let usdc_asset = StellarAssetClient::new(&setup.env, &setup.usdc_token);
+        usdc_asset.mint(&setup.creator, &setup.amount);
+
+        setup.create_default_vault();
+        assert_eq!(client.vault_count(), 1);
+
+        setup.create_default_vault();
+        assert_eq!(client.vault_count(), 2);
+    }
+
+    #[test]
     fn test_release_funds_after_validation() {
         let setup = TestSetup::new();
         let client = setup.client();


### PR DESCRIPTION
## Summary

Fixes #327.

Adds direct test coverage for the public read-only `vault_count()` entrypoint.

## Changes

- Assert `vault_count()` starts at `0`
- Create one vault and assert the count becomes `1`
- Create a second vault and assert the count becomes `2`

## Verification

- Ran `git diff --check`
- Could not run Cargo locally because `cargo` is not installed in this environment

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the issue, existing ID sequencing test, and final diff before submitting.