### PR TITLE
Test release at exact deadline

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -851,6 +851,29 @@ mod tests {
     }
 
     #[test]
+    fn test_release_funds_at_exact_deadline() {
+        let setup = TestSetup::new();
+        let client = setup.client();
+
+        setup.env.ledger().set_timestamp(setup.start_timestamp);
+        let vault_id = setup.create_default_vault();
+
+        // The release deadline is inclusive: now >= end_timestamp.
+        setup.env.ledger().set_timestamp(setup.end_timestamp);
+
+        let usdc = setup.usdc_client();
+        let before = usdc.balance(&setup.success_dest);
+
+        let result = client.release_funds(&vault_id, &setup.usdc_token);
+        assert!(result);
+
+        assert_eq!(usdc.balance(&setup.success_dest) - before, setup.amount);
+
+        let vault = client.get_vault_state(&vault_id).unwrap();
+        assert_eq!(vault.status, VaultStatus::Completed);
+    }
+
+    #[test]
     fn test_double_release_rejected() {
         let setup = TestSetup::new();
         let client = setup.client();


### PR DESCRIPTION
## Summary

Fixes #331.

Adds a boundary test proving `release_funds` succeeds when the ledger timestamp is exactly equal to `end_timestamp`.

## Changes

- Add `test_release_funds_at_exact_deadline`
- Set ledger timestamp to `setup.end_timestamp`, not `end_timestamp + 1`
- Assert funds move to `success_destination`
- Assert the vault reaches `Completed`

## Verification

- Ran `git diff --check`
- Could not run Cargo locally because `cargo` is not installed in this environment

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the issue, release condition, neighboring tests, and final diff before submitting.