### PR TITLE
Remove empty create_vault test stub

### DIFF
--- a/tests/create_vault.rs
+++ b/tests/create_vault.rs
@@ -1,1 +1,0 @@
-// create_vault integration coverage is currently kept in src/lib.rs.


### PR DESCRIPTION
## Summary

Fixes #329.

Removes the dead `tests/create_vault.rs` integration-test stub, which contained only a comment and no tests.

## Changes

- Delete `tests/create_vault.rs`
- Leave the real create-vault coverage in `src/lib.rs` and the remaining integration/property test files untouched

## Verification

- Ran `git diff --check`
- Confirmed the deleted file contained only a one-line comment
- Could not run Cargo locally because `cargo` is not installed in this environment

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the issue, file contents, and final diff before submitting.