### PR TITLE
Test validate rejects cancelled vault

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -912,6 +912,22 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_milestone_on_cancelled_vault_rejected() {
+        let setup = TestSetup::new();
+        let client = setup.client();
+
+        setup.env.ledger().set_timestamp(setup.start_timestamp);
+        let vault_id = setup.create_default_vault();
+        client.cancel_vault(&vault_id, &setup.usdc_token);
+
+        let result = client.try_validate_milestone(&vault_id);
+        match result {
+            Err(Ok(Error::VaultNotActive)) => {}
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_redirect_funds_after_deadline_without_validation() {
         let setup = TestSetup::new();
         let client = setup.client();


### PR DESCRIPTION
## Summary

Fixes #325.

Adds coverage proving `validate_milestone` rejects a vault that has already been cancelled.

## Changes

- Add `test_validate_milestone_on_cancelled_vault_rejected`
- Create and cancel a vault
- Assert `try_validate_milestone` returns `Error::VaultNotActive`

## Verification

- Ran `git diff --check`
- Could not run Cargo locally because `cargo` is not installed in this environment

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the issue, terminal-state guard, existing validation tests, and final diff before submitting.