### PR TITLE
Test redirect rejects cancelled vault

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -947,6 +947,23 @@ mod tests {
     }
 
     #[test]
+    fn test_redirect_funds_on_cancelled_vault_rejected() {
+        let setup = TestSetup::new();
+        let client = setup.client();
+
+        setup.env.ledger().set_timestamp(setup.start_timestamp);
+        let vault_id = setup.create_default_vault();
+        client.cancel_vault(&vault_id, &setup.usdc_token);
+        setup.env.ledger().set_timestamp(setup.end_timestamp + 1);
+
+        let result = client.try_redirect_funds(&vault_id, &setup.usdc_token);
+        match result {
+            Err(Ok(Error::VaultNotActive)) => {}
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_double_redirect_rejected() {
         let setup = TestSetup::new();
         let client = setup.client();


### PR DESCRIPTION
## Summary

Fixes #323.

Adds coverage proving `redirect_funds` rejects a vault that has already been cancelled.

## Changes

- Add `test_redirect_funds_on_cancelled_vault_rejected`
- Create and cancel a vault
- Move past the deadline
- Assert `try_redirect_funds` returns `Error::VaultNotActive`

## Verification

- Ran `git diff --check`
- Could not run Cargo locally because `cargo` is not installed in this environment

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the issue, redirect status guard, existing tests, and final diff before submitting.