### PR TITLE
Test release rejects failed vault

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -883,6 +883,23 @@ mod tests {
     }
 
     #[test]
+    fn test_release_failed_vault_rejected() {
+        let setup = TestSetup::new();
+        let client = setup.client();
+
+        setup.env.ledger().set_timestamp(setup.start_timestamp);
+        let vault_id = setup.create_default_vault();
+        setup.env.ledger().set_timestamp(setup.end_timestamp + 1);
+        client.redirect_funds(&vault_id, &setup.usdc_token);
+
+        let result = client.try_release_funds(&vault_id, &setup.usdc_token);
+        match result {
+            Err(Ok(Error::VaultNotActive)) => {}
+            other => panic!("unexpected result: {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_release_not_validated_before_deadline_rejected() {
         let setup = TestSetup::new();
         let client = setup.client();


### PR DESCRIPTION
## Summary

Fixes #321.

Adds coverage proving `release_funds` rejects a vault that has already reached `Failed`.

## Changes

- Add `test_release_failed_vault_rejected`
- Redirect a vault after the deadline so it reaches `Failed`
- Assert `try_release_funds` returns `Error::VaultNotActive`

## Verification

- Ran `git diff --check`
- Could not run Cargo locally because `cargo` is not installed in this environment

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the issue, release status guard, existing tests, and final diff before submitting.