### PR TITLE
Remove inert tarpaulin workspace setting

### DIFF
--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -5,7 +5,6 @@ output-dir = "coverage"
 
 [run]
 all-features = true
-workspace = true
 
 # Exclude test-only modules from coverage denominator so the 95 % threshold
 # reflects production logic only, not test helper code.


### PR DESCRIPTION
## Summary

Fixes #294.

Removes the inert `workspace = true` setting from `tarpaulin.toml` because this repository is a single crate and `Cargo.toml` does not define a workspace.

## Changes

- Delete `[run].workspace = true`
- Leave the rest of the tarpaulin configuration unchanged

## Verification

- Ran `git diff --check`
- Confirmed `Cargo.toml` has `[package]` but no `[workspace]` table
- Could not run Cargo/tarpaulin locally because Cargo is not installed in this environment

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the issue, Cargo.toml, tarpaulin.toml, and final diff before submitting.