### PR TITLE
Remove unstable rustfmt options

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,2 @@
-# Rust edition — must match Cargo.toml
+# Rust edition must match Cargo.toml.
 edition = "2021"
-
-# Enforce consistent import grouping: std → external → crate-local
-imports_granularity = "Crate"
-group_imports = "StdExternalCrate"


### PR DESCRIPTION
## Summary

Fixes #295.

Removes rustfmt options that stable rustfmt does not enforce in this repository's CI configuration.

## Changes

- Remove `imports_granularity = "Crate"`
- Remove `group_imports = "StdExternalCrate"`
- Remove the corresponding import-grouping comment
- Keep `edition = "2021"`

## Verification

- Ran `git diff --check`
- Verified the unstable rustfmt option names no longer appear in `rustfmt.toml`
- Could not run rustfmt locally because `rustfmt` is not installed in this environment

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the issue, CI rustfmt toolchain, rustfmt.toml, and final diff before submitting.