### PR TITLE
Scope too_many_arguments allow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![deny(warnings)]
 #![cfg_attr(test, allow(warnings))]
-#![allow(clippy::too_many_arguments)]
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, token, Address, BytesN, Env, Symbol,
@@ -132,6 +131,7 @@ impl DisciplrVault {
     ///
     /// # Prerequisites
     /// Creator must have sufficient USDC balance and authorize the transaction.
+    #[allow(clippy::too_many_arguments)]
     pub fn create_vault(
         env: Env,
         usdc_token: Address,


### PR DESCRIPTION
## Summary

Fixes #291.

Scopes the `clippy::too_many_arguments` allowance to the one function that needs it instead of disabling the lint for the entire crate.

## Changes

- Remove crate-level `#![allow(clippy::too_many_arguments)]`
- Add `#[allow(clippy::too_many_arguments)]` directly to `create_vault`

## Verification

- Ran `git diff --check`
- Could not run clippy locally because Cargo/clippy are not installed in this environment

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the issue, lint location, create_vault signature, and final diff before submitting.