### PR TITLE
Add contract constants to interface

### DIFF
--- a/contract-interface.json
+++ b/contract-interface.json
@@ -2,6 +2,23 @@
   "name": "disciplr-vault",
   "version": "0.1.0",
   "description": "Programmable time-locked USDC vaults on Stellar",
+  "constants": {
+    "MIN_AMOUNT": {
+      "type": "i128",
+      "value": "10000000",
+      "description": "Minimum vault amount in stroops (1 USDC)"
+    },
+    "MAX_AMOUNT": {
+      "type": "i128",
+      "value": "10000000000000",
+      "description": "Maximum vault amount in stroops (10,000,000 USDC)"
+    },
+    "MAX_VAULT_DURATION": {
+      "type": "u64",
+      "value": 31536000,
+      "description": "Maximum vault duration in seconds (365 days)"
+    }
+  },
   "types": {
     "VaultStatus": {
       "type": "enum",


### PR DESCRIPTION
## Summary

Fixes #288.

Adds a machine-readable `constants` section to `contract-interface.json` for the public vault bounds defined in `src/lib.rs`.

## Changes

- Add `MIN_AMOUNT` as `i128` with value `10000000`
- Add `MAX_AMOUNT` as `i128` with value `10000000000000`
- Add `MAX_VAULT_DURATION` as `u64` with value `31536000`
- Include short descriptions for each constant

## Verification

- Ran `git diff --check`
- Parsed `contract-interface.json` with `ConvertFrom-Json`
- Cross-checked values against `src/lib.rs`

## AI disclosure

This PR was prepared with assistance from OpenAI Codex in the Codex desktop app, using GPT-5. I reviewed the issue, source constants, JSON structure, parser output, and final diff before submitting.