### PR TITLE
test: cover redirect rejection after completed vault

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -947,6 +947,26 @@ mod tests {
     }
 
     #[test]
+    fn test_redirect_funds_on_completed_vault_rejects_with_vault_not_active() {
+        let setup = TestSetup::new();
+        let client = setup.client();
+
+        setup.env.ledger().set_timestamp(setup.start_timestamp);
+        let vault_id = setup.create_default_vault();
+        setup.env.ledger().set_timestamp(setup.end_timestamp + 1);
+
+        let result = client.release_funds(&vault_id, &setup.usdc_token);
+        assert!(result);
+        assert_eq!(
+            client.try_redirect_funds(&vault_id, &setup.usdc_token),
+            Err(Ok(Error::VaultNotActive))
+        );
+
+        let vault = client.get_vault_state(&vault_id).unwrap();
+        assert_eq!(vault.status, VaultStatus::Completed);
+    }
+
+    #[test]
     fn test_double_redirect_rejected() {
         let setup = TestSetup::new();
         let client = setup.client();

--- a/tests/proptest_timestamps.rs
+++ b/tests/proptest_timestamps.rs
@@ -279,7 +279,6 @@ fn edge_start_eq_now_succeeds() {
     assert_eq!(vault.end_timestamp, end);
 }
 
-
 #[test]
 fn edge_start_eq_end_rejected() {
     let (env, client, usdc, usdc_asset) = setup();


### PR DESCRIPTION
Fixes #322.

Adds a lifecycle regression test that completes a vault through `release_funds`, then verifies `redirect_funds` rejects the terminal Completed state with `Error::VaultNotActive`.

Validation: static API inspection only in this environment; I did not run the Soroban/Rust toolchain locally to avoid dependency/toolchain execution here.