### PR TITLE
Document read-only entries in authorization matrix

### DIFF
--- a/src/doc.md
+++ b/src/doc.md
@@ -591,6 +591,8 @@ All transactions benefit from Stellar's built-in replay protection via sequence 
 | `release_funds` | Anyone | Conditions: validated OR past deadline |
 | `redirect_funds` | Anyone | Conditions: not validated AND past deadline |
 | `cancel_vault` | Creator only | Vault must be Active |
+| `get_vault_state` | Anyone (read-only, no auth) | Returns `Some(ProductivityVault)` for an existing vault id, otherwise `None` |
+| `vault_count` | Anyone (read-only, no auth) | Returns the total number of vault ids assigned so far |
 
 ---
 


### PR DESCRIPTION
Fixes #344.

Completes the `src/doc.md` authorization matrix by adding the two read-only entrypoints that were missing:

- `get_vault_state` as anyone-callable, read-only, no auth
- `vault_count` as anyone-callable, read-only, no auth

Validation: static documentation/API review only; no project toolchain commands were run from this environment.