### PR TITLE
Align testing guide filters with real tests

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -59,42 +59,43 @@ See [COVERAGE_ANALYSIS.md](./COVERAGE_ANALYSIS.md) for detailed breakdown.
 
 ## Test Categories
 
-### 1. Valid State Transitions (4 tests)
+### 1. Lifecycle Scenarios (2 tests)
 
-Tests all valid vault state changes:
+Runs the concrete lifecycle tests currently defined in `tests/lifecycle.rs`:
 
 ```bash
-cargo test test_active_to_completed
-cargo test test_active_to_failed
-cargo test test_active_to_cancelled
+cargo test test_full_lifecycle_success
+cargo test test_full_lifecycle_failure_redirection
 ```
 
-### 2. Terminal State Protection (12 tests)
+### 2. Amount Validation (5 tests)
 
-Security tests ensuring terminal states are immutable:
+Runs the property and edge-case amount tests from `tests/proptest_amounts.rs`:
 
 ```bash
-cargo test test_completed_cannot
-cargo test test_failed_cannot
-cargo test test_cancelled_cannot
+cargo test prop_amount_in_range
+cargo test edge_amount
 ```
 
-### 3. Event Emission (6 tests)
+### 3. Timestamp Validation (9 tests)
 
-Verifies audit trail logging:
+Runs the property and boundary timestamp tests from `tests/proptest_timestamps.rs`:
 
 ```bash
-cargo test test_.*_emits_event
+cargo test prop_create_vault
+cargo test prop_duration_boundary
+cargo test prop_past_start_rejected
+cargo test edge_start
+cargo test edge_zero_start
+cargo test edge_max_duration
 ```
 
-### 4. Data Integrity (10 tests)
+### 4. Create Vault Integration
 
-Edge cases and comprehensive validation:
+Runs the create-vault integration test module by test target name:
 
 ```bash
-cargo test test_vault_creation
-cargo test test_vault_data_integrity
-cargo test test_sequential_operations
+cargo test --test create_vault
 ```
 
 ## Coverage Reports

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -164,10 +164,8 @@ cat test_snapshots/test/test_vault_creation_emits_event.1.json
 ### Double-Spending Prevention
 
 ```bash
-# Run terminal state protection tests
-cargo test test_completed_cannot
-cargo test test_failed_cannot
-cargo test test_cancelled_cannot
+# Run the lifecycle path that redirects funds after a failed milestone
+cargo test test_full_lifecycle_failure_redirection
 ```
 
 ### State Machine Integrity


### PR DESCRIPTION
Fixes #351.

Updates `TESTING_GUIDE.md` so the Test Categories section uses filters that match the tests currently present in the repository:

- lifecycle scenarios: `test_full_lifecycle_success` and `test_full_lifecycle_failure_redirection`
- amount validation: `prop_amount_in_range` and `edge_amount`
- timestamp validation: `prop_create_vault`, `prop_duration_boundary`, `prop_past_start_rejected`, and edge timestamp filters
- create-vault integration: target-level `cargo test --test create_vault`

Validation: static repository/API inspection only; no project toolchain commands were run from this environment.