### PR TITLE
Add pull request checklist template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+- 
+
+## Checklist
+
+- [ ] Tests were added or updated for the touched behavior, or the PR explains why no test change is needed.
+- [ ] `cargo test` passes locally, or any failure is documented with the reason.
+- [ ] `cargo fmt -- --check` passes locally.
+- [ ] `cargo clippy -- -D warnings` passes locally, or any existing unrelated failure is documented.
+- [ ] Documentation was updated for user-facing, integration-facing, or reviewer-facing changes.
+- [ ] The branch contains no unresolved merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`); see [`docs/MERGE_HYGIENE.md`](../docs/MERGE_HYGIENE.md).
+
+## Verification
+
+List the commands run and their results, including coverage evidence when the PR touches contract logic.
+
+```text
+
+```
+


### PR DESCRIPTION
## Summary
- Adds `.github/PULL_REQUEST_TEMPLATE.md` so new PRs pre-populate with the requested test, formatting, lint, docs, and merge-marker checklist.
- Includes a verification section for commands/results and coverage evidence when contract logic is touched.

Closes #268.

## Validation
- `git diff --check`
- Static marker check confirmed the template includes tests, `cargo test`, `cargo fmt -- --check`, `cargo clippy -- -D warnings`, docs, conflict markers, and verification prompts.

No project dependencies or toolchains were installed or executed; this is a repository metadata/docs-only change.