### PR TITLE
test: verify release_funds succeeds at exact deadline

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -851,6 +851,28 @@ mod tests {
     }
 
     #[test]
+    fn test_release_funds_at_exact_deadline() {
+        let setup = TestSetup::new();
+        let client = setup.client();
+
+        setup.env.ledger().set_timestamp(setup.start_timestamp);
+        let vault_id = setup.create_default_vault();
+        let vault = client.get_vault_state(&vault_id).unwrap();
+
+        setup.env.ledger().set_timestamp(vault.end_timestamp);
+
+        let usdc = setup.usdc_client();
+        let before = usdc.balance(&setup.success_dest);
+
+        let result = client.release_funds(&vault_id, &setup.usdc_token);
+        assert!(result);
+        assert_eq!(usdc.balance(&setup.success_dest) - before, setup.amount);
+
+        let vault = client.get_vault_state(&vault_id).unwrap();
+        assert_eq!(vault.status, VaultStatus::Completed);
+    }
+
+    #[test]
     fn test_double_release_rejected() {
         let setup = TestSetup::new();
         let client = setup.client();


### PR DESCRIPTION
## Summary

- Add a dedicated test for the inclusive `release_funds` deadline boundary.
- Set the ledger timestamp to the persisted vault's exact `end_timestamp`.
- Verify successful release, destination balance transfer, and `Completed` status.

## Test evidence

- `cargo test test_release_funds_at_exact_deadline --locked`
- `cargo test --locked` (67 tests passed)
- `cargo build --locked --verbose`
- `cargo clippy --locked -- -D warnings`
- `cargo fmt -- --check`
- Merge-conflict marker guard
- `git diff --check`

Fixes #331

### Verification
- `Focused exact-deadline test passed (1 test)`
- `Full cargo test --locked passed (67 tests)`
- `cargo build --locked --verbose passed`
- `cargo clippy --locked -- -D warnings passed`
- `cargo fmt -- --check passed`
- `Merge-conflict marker guard passed`
- `git diff --check passed`

### Diagnostics
Recovered command failures: `/bin/zsh -lc 'cargo test test_release_funds_at_exact_deadline -- --exact'` (101)