### PR TITLE
docs: add README discovery links

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,13 @@ Any attempt to call `validate_milestone`, `release_funds`, `redirect_funds`, or
   for integrators and tooling.
 - [`src/doc.md`](src/doc.md) maps these contract semantics to backend API
   payloads and HTTP error responses.
+
+## Further Reading
+
+- [`vesting.md`](vesting.md) documents the vault data model, contract methods,
+  and security and trust model.
+- [`USDC_INTEGRATION.md`](USDC_INTEGRATION.md) explains the token integration
+  and production USDC trust assumptions.
+- [`TESTING_GUIDE.md`](TESTING_GUIDE.md) explains how to run and extend the
+  contract tests.
+- [`CHANGELOG.md`](CHANGELOG.md) records the contract's release history.


### PR DESCRIPTION
## Summary

- add a `Further Reading` section to the root README
- link the vesting, USDC integration, testing, and release-history documents
- describe each link so readers can find the relevant contract guidance quickly

## Changes

- linked `vesting.md`
- linked `USDC_INTEGRATION.md`
- linked `TESTING_GUIDE.md`
- linked `CHANGELOG.md`

## Testing / Verification

- confirmed all four relative link targets exist at the repository root
- parsed the README's local links and confirmed every target resolves
- confirmed each requested link appears exactly once
- confirmed the commit changes only `README.md`
- `git diff HEAD^ HEAD --check`

No dependency-backed documentation verifier is configured in the repository, so no dependency installation was required for this README-only change.

Fixes #353
