### PR TITLE
docs: centralize merge hygiene guidance

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -2,10 +2,10 @@
 
 ## Quick Start
 
-```bash
-# Check for unresolved merge conflict markers
-git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- .
+Before running the test commands below, follow the canonical conflict-marker
+check and resolution steps in [Merge Hygiene](./docs/MERGE_HYGIENE.md).
 
+```bash
 # Run all tests
 cargo test
 
@@ -118,11 +118,6 @@ cargo tarpaulin --out Html --out Xml --out Lcov --output-dir coverage
 # GitHub Actions workflow included
 .github/workflows/coverage.yml
 ```
-
-The main CI workflow also runs a merge-conflict marker guard before formatting,
-build, and tests. The guard fails if any file contains a line starting with
-`<<<<<<<`, `=======`, or `>>>>>>>`. See [docs/MERGE_HYGIENE.md](./docs/MERGE_HYGIENE.md)
-for the local check and resolution steps.
 
 ## Understanding Coverage Metrics
 


### PR DESCRIPTION
## Summary

- replace the duplicate merge-marker command in Quick Start with a link to the canonical merge-hygiene guide
- remove the repeated CI/marker explanation from Coverage Reports
- preserve the existing Quick Start test and coverage commands

## Changes

- update `TESTING_GUIDE.md` only
- leave `docs/MERGE_HYGIENE.md` as the single source of the command and resolution workflow

## Testing / Verification

- confirmed the relative `docs/MERGE_HYGIENE.md` link resolves
- confirmed the exact marker command appears once in documentation, in `docs/MERGE_HYGIENE.md`, and no longer appears in `TESTING_GUIDE.md`; CI continues to execute the check
- confirmed the canonical document is unchanged
- ran the anchored merge-conflict marker guard with no findings
- ran `git diff --check`

Fixes #352
