### PR TITLE
docs: link to live repository tree

### DIFF
--- a/vesting.md
+++ b/vesting.md
@@ -475,16 +475,9 @@ Expected output should include tests for:
 
 ## File Structure
 
-```
-disciplr-contracts/
-├── src/
-│   └── lib.rs           # DisciplrVault contract implementation
-├── tests/
-│   └── create_vault.rs  # Integration tests for create_vault
-├── Cargo.toml           # Project dependencies
-├── README.md            # Project overview
-└── vesting.md           # This documentation
-```
+The repository layout changes as tests, documentation, workflows, and tooling
+evolve. See the [live repository tree](https://github.com/Disciplr-Org/Disciplr-Contracts)
+for the current, complete file structure.
 
 ---
 


### PR DESCRIPTION
## Summary

- replace the stale five-entry file tree with a link to the live repository listing
- keep the file-structure guidance accurate as tests, docs, workflows, and tooling evolve

## Changes

- update the `File Structure` section in `vesting.md` only
- remove the incomplete static tree without changing contract or test behavior

## Testing / Verification

- confirmed the live repository link returns HTTP 200
- confirmed the issue-cited paths exist in the current repository tree
- confirmed the stale diagram is absent and Markdown fences remain balanced
- ran `git diff --check`

Fixes #356
